### PR TITLE
Add Sublime Security Rules as a detection source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Security Detections MCP
 
-An MCP (Model Context Protocol) server that lets LLMs query a unified database of **Sigma**, **Splunk ESCU**, **Elastic**, and **KQL** security detection rules.
+An MCP (Model Context Protocol) server that lets LLMs query a unified database of **Sigma**, **Splunk ESCU**, **Elastic**, **KQL**, and **Sublime** security detection rules.
 
 > **New here? Start with the [Setup Guide](./SETUP.md)** -- covers macOS, Windows (WSL & native), and Linux step by step.
 
@@ -213,7 +213,7 @@ Claude will:
 - **🆕 Server Instructions** - Built-in usage guide with examples for better LLM understanding
 - **🆕 Structured Errors** - Helpful error messages with suggestions and similar items
 - **🆕 Interactive Tools** - Gap prioritization and sprint planning with form-based input (Cursor 0.42+)
-- **Unified Search** - Query Sigma, Splunk ESCU, Elastic, and KQL detections from a single interface
+- **Unified Search** - Query Sigma, Splunk ESCU, Elastic, KQL, and Sublime detections from a single interface
 - **Full-Text Search** - SQLite FTS5 powered search across names, descriptions, queries, MITRE tactics, CVEs, process names, and more
 - **MITRE ATT&CK Mapping** - Filter detections by technique ID or tactic
 - **CVE Coverage** - Find detections for specific CVE vulnerabilities
@@ -221,7 +221,7 @@ Claude will:
 - **Analytic Stories** - Query by Splunk analytic story (optional - enhances context)
 - **KQL Categories** - Filter KQL queries by category (Defender For Endpoint, Azure AD, Threat Hunting, etc.)
 - **Auto-Indexing** - Automatically indexes detections on startup from configured paths
-- **Multi-Format Support** - YAML (Sigma, Splunk), TOML (Elastic), Markdown (KQL)
+- **Multi-Format Support** - YAML (Sigma, Splunk, Sublime), TOML (Elastic), Markdown (KQL)
 - **Logsource Filtering** - Filter Sigma rules by category, product, or service
 - **Severity Filtering** - Filter by criticality level
 
@@ -261,7 +261,8 @@ Add to your MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json` in your proje
         "SPLUNK_PATHS": "/path/to/security_content/detections",
         "ELASTIC_PATHS": "/path/to/detection-rules/rules",
         "STORY_PATHS": "/path/to/security_content/stories",
-        "KQL_PATHS": "/path/to/Hunting-Queries-Detection-Rules"
+        "KQL_PATHS": "/path/to/Hunting-Queries-Detection-Rules",
+        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules"
       }
     }
   }
@@ -283,7 +284,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
         "SPLUNK_PATHS": "/Users/you/security_content/detections",
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "STORY_PATHS": "/Users/you/security_content/stories",
-        "KQL_PATHS": "/Users/you/Hunting-Queries-Detection-Rules"
+        "KQL_PATHS": "/Users/you/Hunting-Queries-Detection-Rules",
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
       }
     }
   }
@@ -305,7 +307,8 @@ Add to `~/.vscode/mcp.json`:
         "SPLUNK_PATHS": "/Users/you/security_content/detections",
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "KQL_PATHS": "/Users/you/kql-bertjanp,/Users/you/kql-jkerai1",
-        "STORY_PATHS": "/Users/you/security_content/stories"
+        "STORY_PATHS": "/Users/you/security_content/stories",
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
       }
     }
   }
@@ -327,7 +330,8 @@ Add to `~/.vscode/mcp.json`:
         "SPLUNK_PATHS": "/Users/you/security_content/detections",
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "KQL_PATHS": "/Users/you/kql-bertjanp,/Users/you/kql-jkerai1",
-        "STORY_PATHS": "/Users/you/security_content/stories"
+        "STORY_PATHS": "/Users/you/security_content/stories",
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
       }
     }
   }
@@ -341,6 +345,7 @@ Add to `~/.vscode/mcp.json`:
 | `SPLUNK_PATHS` | Comma-separated paths to Splunk ESCU detection directories | At least one source required |
 | `ELASTIC_PATHS` | Comma-separated paths to Elastic detection rule directories | At least one source required |
 | `KQL_PATHS` | Comma-separated paths to KQL hunting query directories | At least one source required |
+| `SUBLIME_PATHS` | Comma-separated paths to Sublime Security rule directories | At least one source required |
 | `STORY_PATHS` | Comma-separated paths to Splunk analytic story directories | No (enhances context) |
 
 ## Getting Detection Content
@@ -369,11 +374,16 @@ cd detection-rules && git sparse-checkout set rules && cd ..
 git clone --depth 1 https://github.com/Bert-JanP/Hunting-Queries-Detection-Rules.git kql-bertjanp
 git clone --depth 1 https://github.com/jkerai1/KQL-Queries.git kql-jkerai1
 
+# Download Sublime Security email detection rules (~900+ rules)
+git clone --depth 1 --filter=blob:none --sparse https://github.com/sublime-security/sublime-rules.git
+cd sublime-rules && git sparse-checkout set detection-rules && cd ..
+
 echo "Done! Configure your MCP with these paths:"
 echo "  SIGMA_PATHS: $(pwd)/sigma/rules,$(pwd)/sigma/rules-threat-hunting"
 echo "  SPLUNK_PATHS: $(pwd)/security_content/detections"
 echo "  ELASTIC_PATHS: $(pwd)/detection-rules/rules"
 echo "  KQL_PATHS: $(pwd)/kql-bertjanp,$(pwd)/kql-jkerai1"
+echo "  SUBLIME_PATHS: $(pwd)/sublime-rules/detection-rules"
 echo "  STORY_PATHS: $(pwd)/security_content/stories"
 ```
 
@@ -398,6 +408,10 @@ git clone https://github.com/elastic/detection-rules.git
 git clone https://github.com/Bert-JanP/Hunting-Queries-Detection-Rules.git
 git clone https://github.com/jkerai1/KQL-Queries.git
 # Use entire repos, combine paths with comma
+
+# Sublime Security Rules
+git clone https://github.com/sublime-security/sublime-rules.git
+# Use detection-rules/ directory
 ```
 
 ## 🆕 MCP Resources - Readable Context
@@ -427,7 +441,7 @@ The server provides **autocomplete suggestions** as you type argument values:
 | `process_name` | Process names in your detections (powershell.exe, etc.) |
 | `tactic` | All 14 MITRE tactics |
 | `severity` | informational, low, medium, high, critical |
-| `source_type` | sigma, splunk_escu, elastic, kql |
+| `source_type` | sigma, splunk_escu, elastic, kql, sublime |
 | `threat_profile` | ransomware, apt, initial-access, persistence, etc. |
 
 This prevents typos and helps discover what values are available in your detection corpus.
@@ -486,7 +500,7 @@ Tool: prioritize_gaps(threat_profile="ransomware")
 | `search(query, limit)` | Full-text search across all detection fields (names, descriptions, queries, CVEs, process names, etc.) |
 | `get_by_id(id)` | Get a single detection by its ID |
 | `list_all(limit, offset)` | Paginated list of all detections |
-| `list_by_source(source_type)` | Filter by `sigma`, `splunk_escu`, `elastic`, or `kql` |
+| `list_by_source(source_type)` | Filter by `sigma`, `splunk_escu`, `elastic`, `kql`, or `sublime` |
 | `get_raw_yaml(id)` | Get the original YAML/TOML/Markdown content |
 | `get_stats()` | Get index statistics |
 | `rebuild_index()` | Force re-index from configured paths |
@@ -837,7 +851,7 @@ Tool: list_by_cve(cve_id="CVE-2024-27198")
 ```
 LLM: "What detections do we have for credential dumping?"
 Tool: search(query="credential dumping", limit=10)
-→ Returns results from Sigma, Splunk, Elastic, AND KQL
+→ Returns results from Sigma, Splunk, Elastic, KQL, AND Sublime
 ```
 
 #### Find Web Server Attack Detections
@@ -862,6 +876,14 @@ LLM: "What KQL queries do we have for Defender For Endpoint?"
 Tool: list_by_kql_category(category="Defender For Endpoint")
 ```
 
+#### Find BEC/Phishing Email Detections
+
+```
+LLM: "What email detections do we have for BEC fraud?"
+Tool: list_by_source(source_type="sublime")
+→ Returns Sublime Security email detection rules for BEC, phishing, malware, etc.
+```
+
 #### Search for BloodHound Detections
 
 ```
@@ -872,7 +894,7 @@ Tool: search(query="bloodhound", limit=10)
 
 ## Unified Schema
 
-All detection sources (Sigma, Splunk, Elastic, KQL) are normalized to a common schema:
+All detection sources (Sigma, Splunk, Elastic, KQL, Sublime) are normalized to a common schema:
 
 ### Core Fields
 
@@ -881,8 +903,8 @@ All detection sources (Sigma, Splunk, Elastic, KQL) are normalized to a common s
 | `id` | Unique identifier |
 | `name` | Detection name/title |
 | `description` | What the detection looks for |
-| `query` | Detection logic (Sigma YAML, Splunk SPL, Elastic EQL, or KQL) |
-| `source_type` | `sigma`, `splunk_escu`, `elastic`, or `kql` |
+| `query` | Detection logic (Sigma YAML, Splunk SPL, Elastic EQL, KQL, or Sublime MQL) |
+| `source_type` | `sigma`, `splunk_escu`, `elastic`, `kql`, or `sublime` |
 | `severity` | Detection severity level |
 | `status` | Rule status (stable, test, experimental, production, etc.) |
 | `author` | Rule author |
@@ -913,6 +935,14 @@ All detection sources (Sigma, Splunk, Elastic, KQL) are normalized to a common s
 | `kql_tags` | Extracted tags (e.g., "ransomware", "hunting", "ti-feed") |
 | `kql_keywords` | Security keywords extracted for search |
 | `platforms` | Platforms (windows, azure-ad, office-365, etc.) |
+
+### Sublime-Specific Fields
+
+| Field | Description |
+|-------|-------------|
+| `sublime_attack_types` | Attack types (BEC/Fraud, Credential Phishing, Malware/Ransomware, etc.) |
+| `sublime_detection_methods` | Detection methods (Content analysis, URL analysis, Computer Vision, etc.) |
+| `sublime_tactics` | Tactics and techniques (Evasion, Impersonation: Brand, Social engineering, etc.) |
 
 ## Database
 
@@ -950,6 +980,14 @@ From [Elastic Detection Rules](https://github.com/elastic/detection-rules):
 - Required: `rule.name`, `rule.rule_id`
 - Optional: `rule.description`, `rule.query`, `rule.severity`, `rule.tags`, `rule.threat` (MITRE mappings)
 - Supports EQL, KQL, Lucene, and ESQL query languages
+
+### Sublime Security Rules (YAML)
+
+From [Sublime Security](https://github.com/sublime-security/sublime-rules):
+- Required: `name`, `type` (rule/exclusion), `source` (MQL query)
+- Optional: `description`, `severity`, `id`, `references`, `tags`, `authors`, `attack_types`, `tactics_and_techniques`, `detection_methods`, `false_positives`
+- Uses MQL (Message Query Language) for email-specific detection logic
+- Covers BEC/fraud, credential phishing, malware delivery, spam, and more
 
 ### KQL Hunting Queries (Markdown & Raw .kql)
 
@@ -1035,6 +1073,7 @@ SIGMA_PATHS="./detections/sigma/rules" \
 SPLUNK_PATHS="./detections/splunk/detections" \
 ELASTIC_PATHS="./detections/elastic/rules" \
 KQL_PATHS="./detections/kql" \
+SUBLIME_PATHS="./detections/sublime-rules/detection-rules" \
 STORY_PATHS="./detections/splunk/stories" \
 npm start
 ```
@@ -1049,11 +1088,12 @@ When fully indexed with all sources:
 | Splunk ESCU | ~2,000+ |
 | Elastic Rules | ~1,500+ |
 | KQL Queries | ~420+ |
+| Sublime Rules | ~900+ |
 | Analytic Stories | ~330 |
-| **Total Detections** | **~7,200+** |
+| **Total Detections** | **~8,100+** |
 | **Indexed Patterns** | **10,235+** |
 | **Techniques with Patterns** | **528+** |
-| **Detection Formats** | **4** (Sigma, Splunk, Elastic, KQL) |
+| **Detection Formats** | **5** (Sigma, Splunk, Elastic, KQL, Sublime) |
 | **Total Tools** | **71+** |
 | **MCP Prompts** | **11** |
 | **MCP Resources** | **9 static + 5 templates** |
@@ -1158,7 +1198,7 @@ For detailed information on v2.1 features:
 
 | MCP | Purpose |
 |-----|---------|
-| **security-detections-mcp** | Query 7,200+ detection rules + 11 expert workflow prompts |
+| **security-detections-mcp** | Query 8,100+ detection rules + 11 expert workflow prompts |
 | **mitre-attack-mcp** | ATT&CK framework data, threat groups, Navigator layers |
 
 ### With MCP Prompts (Easiest)
@@ -1224,7 +1264,8 @@ LLM workflow:
         "SIGMA_PATHS": "/path/to/sigma/rules",
         "SPLUNK_PATHS": "/path/to/security_content/detections",
         "ELASTIC_PATHS": "/path/to/detection-rules/rules",
-        "KQL_PATHS": "/path/to/kql-hunting-queries"
+        "KQL_PATHS": "/path/to/kql-hunting-queries",
+        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules"
       }
     },
     "mitre-attack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,6 +536,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1609,6 +1610,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/db.ts
+++ b/src/db.ts
@@ -58,7 +58,10 @@ export function initDb(): Database.Database {
       platforms TEXT,
       kql_category TEXT,
       kql_tags TEXT,
-      kql_keywords TEXT
+      kql_keywords TEXT,
+      sublime_attack_types TEXT,
+      sublime_detection_methods TEXT,
+      sublime_tactics TEXT
     )
   `);
   
@@ -82,32 +85,35 @@ export function initDb(): Database.Database {
       kql_category,
       kql_tags,
       kql_keywords,
+      sublime_attack_types,
+      sublime_detection_methods,
+      sublime_tactics,
       content='detections',
       content_rowid='rowid'
     )
   `);
-  
+
   // Create triggers to keep FTS in sync
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_ai AFTER INSERT ON detections BEGIN
-      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords);
+      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords, NEW.sublime_attack_types, NEW.sublime_detection_methods, NEW.sublime_tactics);
     END
   `);
-  
+
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_ad AFTER DELETE ON detections BEGIN
-      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords);
+      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords, OLD.sublime_attack_types, OLD.sublime_detection_methods, OLD.sublime_tactics);
     END
   `);
-  
+
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_au AFTER UPDATE ON detections BEGIN
-      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords);
-      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords);
+      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords, OLD.sublime_attack_types, OLD.sublime_detection_methods, OLD.sublime_tactics);
+      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords, NEW.sublime_attack_types, NEW.sublime_detection_methods, NEW.sublime_tactics);
     END
   `);
   
@@ -223,15 +229,16 @@ export function insertDetection(detection: Detection): void {
   const database = initDb();
   
   const stmt = database.prepare(`
-    INSERT OR REPLACE INTO detections 
-    (id, name, description, query, source_type, mitre_ids, logsource_category, 
-     logsource_product, logsource_service, severity, status, author, 
+    INSERT OR REPLACE INTO detections
+    (id, name, description, query, source_type, mitre_ids, logsource_category,
+     logsource_product, logsource_service, severity, status, author,
      date_created, date_modified, refs, falsepositives, tags, file_path, raw_yaml,
      cves, analytic_stories, data_sources, detection_type, asset_type, security_domain,
-     process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords,
+     sublime_attack_types, sublime_detection_methods, sublime_tactics)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
-  
+
   stmt.run(
     detection.id,
     detection.name,
@@ -265,7 +272,10 @@ export function insertDetection(detection: Detection): void {
     JSON.stringify(detection.platforms),
     detection.kql_category,
     JSON.stringify(detection.kql_tags),
-    JSON.stringify(detection.kql_keywords)
+    JSON.stringify(detection.kql_keywords),
+    JSON.stringify(detection.sublime_attack_types),
+    JSON.stringify(detection.sublime_detection_methods),
+    JSON.stringify(detection.sublime_tactics)
   );
 }
 
@@ -275,7 +285,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
     mitre_ids: JSON.parse(row.mitre_ids as string || '[]'),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -304,6 +314,9 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     kql_category: row.kql_category as string | null,
     kql_tags: JSON.parse(row.kql_tags as string || '[]'),
     kql_keywords: JSON.parse(row.kql_keywords as string || '[]'),
+    sublime_attack_types: JSON.parse(row.sublime_attack_types as string || '[]'),
+    sublime_detection_methods: JSON.parse(row.sublime_detection_methods as string || '[]'),
+    sublime_tactics: JSON.parse(row.sublime_tactics as string || '[]'),
   };
 }
 
@@ -341,7 +354,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
   return rows.map(rowToDetection);
 }
 
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime', limit: number = 100, offset: number = 0): Detection[] {
   const database = initDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -539,7 +552,8 @@ export function getStats(): IndexStats {
   const splunk = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'splunk_escu'").get() as { count: number }).count;
   const elastic = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'elastic'").get() as { count: number }).count;
   const kql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'kql'").get() as { count: number }).count;
-  
+  const sublime = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'sublime'").get() as { count: number }).count;
+
   // Count by severity
   const severityRows = database.prepare(`
     SELECT severity, COUNT(*) as count FROM detections 
@@ -629,6 +643,7 @@ export function getStats(): IndexStats {
     splunk_escu: splunk,
     elastic,
     kql,
+    sublime,
     by_severity,
     by_logsource_product,
     mitre_coverage,
@@ -1350,7 +1365,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
 
 // Get name+ID list filtered by source
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1444,7 +1459,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
 // Get detection names and IDs matching a pattern, grouped by source
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = initDb();
   

--- a/src/db/detections.ts
+++ b/src/db/detections.ts
@@ -21,7 +21,7 @@ export interface ValidationResult {
 }
 
 export interface TechniqueIdFilters {
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
   tactic?: string;
   severity?: string;
 }
@@ -54,7 +54,7 @@ export interface DetectionSuggestion {
 export interface NavigatorLayerOptions {
   name: string;
   description?: string;
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
   tactic?: string;
   severity?: string;
 }
@@ -121,7 +121,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
     mitre_ids: safeJsonParse<string[]>(row.mitre_ids as string, []),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -150,6 +150,9 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     kql_category: row.kql_category as string | null,
     kql_tags: safeJsonParse<string[]>(row.kql_tags as string, []),
     kql_keywords: safeJsonParse<string[]>(row.kql_keywords as string, []),
+    sublime_attack_types: safeJsonParse<string[]>(row.sublime_attack_types as string, []),
+    sublime_detection_methods: safeJsonParse<string[]>(row.sublime_detection_methods as string, []),
+    sublime_tactics: safeJsonParse<string[]>(row.sublime_tactics as string, []),
   };
 }
 
@@ -174,15 +177,16 @@ export function insertDetection(detection: Detection): void {
   const database = getDb();
   
   const stmt = database.prepare(`
-    INSERT OR REPLACE INTO detections 
-    (id, name, description, query, source_type, mitre_ids, logsource_category, 
-     logsource_product, logsource_service, severity, status, author, 
+    INSERT OR REPLACE INTO detections
+    (id, name, description, query, source_type, mitre_ids, logsource_category,
+     logsource_product, logsource_service, severity, status, author,
      date_created, date_modified, refs, falsepositives, tags, file_path, raw_yaml,
      cves, analytic_stories, data_sources, detection_type, asset_type, security_domain,
-     process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords,
+     sublime_attack_types, sublime_detection_methods, sublime_tactics)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
-  
+
   stmt.run(
     detection.id,
     detection.name,
@@ -216,7 +220,10 @@ export function insertDetection(detection: Detection): void {
     JSON.stringify(detection.platforms),
     detection.kql_category,
     JSON.stringify(detection.kql_tags),
-    JSON.stringify(detection.kql_keywords)
+    JSON.stringify(detection.kql_keywords),
+    JSON.stringify(detection.sublime_attack_types),
+    JSON.stringify(detection.sublime_detection_methods),
+    JSON.stringify(detection.sublime_tactics)
   );
 }
 
@@ -289,7 +296,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
 /**
  * List detections filtered by source type.
  */
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime', limit: number = 100, offset: number = 0): Detection[] {
   const database = getDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -527,7 +534,8 @@ export function getStats(): IndexStats {
   const splunk = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'splunk_escu'").get() as { count: number }).count;
   const elastic = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'elastic'").get() as { count: number }).count;
   const kql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'kql'").get() as { count: number }).count;
-  
+  const sublime = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'sublime'").get() as { count: number }).count;
+
   // Count by severity
   const severityRows = database.prepare(`
     SELECT severity, COUNT(*) as count FROM detections 
@@ -617,6 +625,7 @@ export function getStats(): IndexStats {
     splunk_escu: splunk,
     elastic,
     kql,
+    sublime,
     by_severity,
     by_logsource_product,
     mitre_coverage,
@@ -804,7 +813,7 @@ export function getTechniqueIds(filters: TechniqueIdFilters = {}): string[] {
 /**
  * Analyze coverage by tactic and identify strengths/weaknesses.
  */
-export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql'): CoverageReport {
+export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'): CoverageReport {
   const database = getDb();
   
   let countSql = 'SELECT COUNT(DISTINCT id) as count FROM detections';
@@ -887,7 +896,7 @@ export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic'
  */
 export function identifyGaps(
   threatProfile: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
 ): GapAnalysis {
   const targetTechniques = THREAT_PROFILES[threatProfile.toLowerCase()] || THREAT_PROFILES['apt'];
   
@@ -943,7 +952,7 @@ export function identifyGaps(
  */
 export function suggestDetections(
   techniqueId: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
 ): DetectionSuggestion {
   const database = getDb();
   
@@ -1100,7 +1109,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
  * List detections by source with optional name filter, returning lightweight results.
  */
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1144,6 +1153,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
     splunk_escu: [],
     elastic: [],
     kql: [],
+    sublime: [],
   };
   
   const byTactic: Record<string, Record<string, number>> = {};
@@ -1192,7 +1202,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
  */
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = getDb();
   
@@ -1236,7 +1246,7 @@ export function countDetectionsBySource(topic: string): Record<string, number> {
   
   const rows = stmt.all(topic) as { source_type: string; count: number }[];
   
-  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0 };
+  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0, sublime: 0 };
   for (const row of rows) {
     result[row.source_type] = row.count;
   }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,7 +60,10 @@ function createDetectionsTable(db: Database.Database): void {
       platforms TEXT,
       kql_category TEXT,
       kql_tags TEXT,
-      kql_keywords TEXT
+      kql_keywords TEXT,
+      sublime_attack_types TEXT,
+      sublime_detection_methods TEXT,
+      sublime_tactics TEXT
     )
   `);
 }
@@ -88,6 +91,9 @@ function createDetectionsFts(db: Database.Database): void {
       kql_category,
       kql_tags,
       kql_keywords,
+      sublime_attack_types,
+      sublime_detection_methods,
+      sublime_tactics,
       content='detections',
       content_rowid='rowid'
     )
@@ -101,26 +107,26 @@ function createDetectionsTriggers(db: Database.Database): void {
   // After INSERT trigger
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_ai AFTER INSERT ON detections BEGIN
-      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords);
+      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords, NEW.sublime_attack_types, NEW.sublime_detection_methods, NEW.sublime_tactics);
     END
   `);
 
   // After DELETE trigger
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_ad AFTER DELETE ON detections BEGIN
-      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords);
+      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords, OLD.sublime_attack_types, OLD.sublime_detection_methods, OLD.sublime_tactics);
     END
   `);
 
   // After UPDATE trigger
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS detections_au AFTER UPDATE ON detections BEGIN
-      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords);
-      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords)
-      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords);
+      INSERT INTO detections_fts(detections_fts, rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES ('delete', OLD.rowid, OLD.id, OLD.name, OLD.description, OLD.query, OLD.mitre_ids, OLD.tags, OLD.cves, OLD.analytic_stories, OLD.data_sources, OLD.process_names, OLD.file_paths, OLD.registry_paths, OLD.mitre_tactics, OLD.platforms, OLD.kql_category, OLD.kql_tags, OLD.kql_keywords, OLD.sublime_attack_types, OLD.sublime_detection_methods, OLD.sublime_tactics);
+      INSERT INTO detections_fts(rowid, id, name, description, query, mitre_ids, tags, cves, analytic_stories, data_sources, process_names, file_paths, registry_paths, mitre_tactics, platforms, kql_category, kql_tags, kql_keywords, sublime_attack_types, sublime_detection_methods, sublime_tactics)
+      VALUES (NEW.rowid, NEW.id, NEW.name, NEW.description, NEW.query, NEW.mitre_ids, NEW.tags, NEW.cves, NEW.analytic_stories, NEW.data_sources, NEW.process_names, NEW.file_paths, NEW.registry_paths, NEW.mitre_tactics, NEW.platforms, NEW.kql_category, NEW.kql_tags, NEW.kql_keywords, NEW.sublime_attack_types, NEW.sublime_detection_methods, NEW.sublime_tactics);
     END
   `);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,11 @@ const SPLUNK_PATHS = parsePaths(process.env.SPLUNK_PATHS);
 const ELASTIC_PATHS = parsePaths(process.env.ELASTIC_PATHS);
 const STORY_PATHS = parsePaths(process.env.STORY_PATHS);
 const KQL_PATHS = parsePaths(process.env.KQL_PATHS);
+const SUBLIME_PATHS = parsePaths(process.env.SUBLIME_PATHS);
 
 // Auto-index on startup if paths are configured and DB is empty
 function autoIndex(): void {
-  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0) {
+  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0) {
     return;
   }
   
@@ -40,9 +41,9 @@ function autoIndex(): void {
   
   if (needsIndexing()) {
     console.error('[security-detections-mcp] Auto-indexing detections...');
-    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS);
+    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS);
     let msg = `[security-detections-mcp] Indexed ${result.total} detections`;
-    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL)`;
+    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL, ${result.sublime_indexed} Sublime)`;
     if (result.stories_indexed > 0) {
       msg += `, ${result.stories_indexed} stories`;
     }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -5,6 +5,7 @@ import { parseSplunkFile } from './parsers/splunk.js';
 import { parseStoryFile } from './parsers/story.js';
 import { parseElasticFile } from './parsers/elastic.js';
 import { parseKqlFile, parseRawKqlFile } from './parsers/kql.js';
+import { parseSublimeFile } from './parsers/sublime.js';
 import { recreateDb, insertDetection, insertStory, getDetectionCount, initDb } from './db.js';
 
 // Recursively find all YAML files in a directory
@@ -133,22 +134,25 @@ export interface IndexResult {
   elastic_failed: number;
   kql_indexed: number;
   kql_failed: number;
+  sublime_indexed: number;
+  sublime_failed: number;
   stories_indexed: number;
   stories_failed: number;
   total: number;
 }
 
 export function indexDetections(
-  sigmaPaths: string[], 
+  sigmaPaths: string[],
   splunkPaths: string[],
   storyPaths: string[] = [],
   elasticPaths: string[] = [],
-  kqlPaths: string[] = []
+  kqlPaths: string[] = [],
+  sublimePaths: string[] = []
 ): IndexResult {
   // Recreate DB to ensure schema is up to date
   recreateDb();
   initDb();
-  
+
   let sigma_indexed = 0;
   let sigma_failed = 0;
   let splunk_indexed = 0;
@@ -157,6 +161,8 @@ export function indexDetections(
   let elastic_failed = 0;
   let kql_indexed = 0;
   let kql_failed = 0;
+  let sublime_indexed = 0;
+  let sublime_failed = 0;
   let stories_indexed = 0;
   let stories_failed = 0;
   
@@ -232,6 +238,21 @@ export function indexDetections(
     }
   }
   
+  // Index Sublime Security rules (YAML with MQL source)
+  for (const basePath of sublimePaths) {
+    const files = findYamlFiles(basePath);
+
+    for (const file of files) {
+      const detection = parseSublimeFile(file);
+      if (detection) {
+        insertDetection(detection);
+        sublime_indexed++;
+      } else {
+        sublime_failed++;
+      }
+    }
+  }
+
   // Index Splunk Analytic Stories (optional)
   for (const basePath of storyPaths) {
     const files = findYamlFiles(basePath);
@@ -256,9 +277,11 @@ export function indexDetections(
     elastic_failed,
     kql_indexed,
     kql_failed,
+    sublime_indexed,
+    sublime_failed,
     stories_indexed,
     stories_failed,
-    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed,
+    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed + sublime_indexed,
   };
 }
 

--- a/src/parsers/elastic.ts
+++ b/src/parsers/elastic.ts
@@ -254,8 +254,11 @@ export function parseElasticFile(filePath: string): Detection | null {
       kql_category: null,
       kql_tags: [],
       kql_keywords: [],
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
     };
-    
+
     return detection;
   } catch (err) {
     // Skip files that can't be parsed

--- a/src/parsers/kql.ts
+++ b/src/parsers/kql.ts
@@ -391,8 +391,11 @@ export function parseRawKqlFile(filePath: string, basePath: string): Detection |
       kql_category: category,
       kql_tags: tags,
       kql_keywords: keywords,
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
     };
-    
+
     return detection;
   } catch {
     return null;
@@ -473,8 +476,11 @@ export function parseKqlFile(filePath: string, basePath: string): Detection | nu
       kql_category: category,
       kql_tags: tags,
       kql_keywords: keywords,
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
     };
-    
+
     return detection;
   } catch {
     return null;

--- a/src/parsers/sigma.ts
+++ b/src/parsers/sigma.ts
@@ -420,8 +420,11 @@ export function parseSigmaFile(filePath: string): Detection | null {
       kql_category: null,
       kql_tags: [],
       kql_keywords: [],
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
     };
-    
+
     return detection;
   } catch (err) {
     // Skip files that can't be parsed

--- a/src/parsers/splunk.ts
+++ b/src/parsers/splunk.ts
@@ -208,8 +208,11 @@ export function parseSplunkFile(filePath: string): Detection | null {
       kql_category: null,
       kql_tags: [],
       kql_keywords: [],
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
     };
-    
+
     return detection;
   } catch (err) {
     // Skip files that can't be parsed

--- a/src/parsers/sublime.ts
+++ b/src/parsers/sublime.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'fs';
+import { parse as parseYaml } from 'yaml';
+import { createHash } from 'crypto';
+import type { Detection, SublimeRule } from '../types.js';
+
+// Best-effort mapping from Sublime tactics_and_techniques to MITRE ATT&CK tactics
+const TACTICS_MAP: Record<string, string> = {
+  'evasion': 'defense-evasion',
+  'exploit': 'execution',
+  'social engineering': 'initial-access',
+  'impersonation: brand': 'initial-access',
+  'impersonation: employee': 'initial-access',
+  'impersonation: vip': 'initial-access',
+  'lookalike domain': 'initial-access',
+  'spoofing': 'initial-access',
+  'scripting': 'execution',
+  'macros': 'execution',
+  'encryption': 'defense-evasion',
+};
+
+// Generate a stable ID from file path and rule name
+function generateId(filePath: string, name: string): string {
+  const hash = createHash('sha256')
+    .update(`${filePath}:${name}`)
+    .digest('hex')
+    .substring(0, 32);
+  return `sublime-${hash}`;
+}
+
+// Extract author names from the authors array
+function extractAuthorNames(authors: SublimeRule['authors']): string | null {
+  if (!authors || authors.length === 0) return null;
+  const names = authors
+    .map(a => a.name || a.twitter || a.github || 'Unknown')
+    .filter(Boolean);
+  return names.length > 0 ? names.join(', ') : null;
+}
+
+// Map Sublime tactics to MITRE ATT&CK tactics (best-effort)
+function mapToMitreTactics(tactics: string[] | undefined): string[] {
+  if (!tactics) return [];
+  const mitreTactics = new Set<string>();
+  for (const tactic of tactics) {
+    const mapped = TACTICS_MAP[tactic.toLowerCase()];
+    if (mapped) {
+      mitreTactics.add(mapped);
+    }
+  }
+  return [...mitreTactics];
+}
+
+export function parseSublimeFile(filePath: string): Detection | null {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const rule = parseYaml(content) as SublimeRule;
+
+    // name and source are required
+    if (!rule.name || !rule.source) {
+      return null;
+    }
+
+    // type must be 'rule' or 'exclusion'
+    if (rule.type !== 'rule' && rule.type !== 'exclusion') {
+      return null;
+    }
+
+    const id = rule.id || generateId(filePath, rule.name);
+
+    const detection: Detection = {
+      id,
+      name: rule.name,
+      description: rule.description || '',
+      query: rule.source,
+      source_type: 'sublime',
+      mitre_ids: [],
+      logsource_category: 'email',
+      logsource_product: 'email',
+      logsource_service: null,
+      severity: rule.severity || null,
+      status: null,
+      author: extractAuthorNames(rule.authors),
+      date_created: null,
+      date_modified: null,
+      references: rule.references || [],
+      falsepositives: rule.false_positives || [],
+      tags: rule.tags || [],
+      file_path: filePath,
+      raw_yaml: content,
+
+      cves: [],
+      analytic_stories: [],
+      data_sources: ['Email Messages', 'Email Headers', 'Email Attachments'],
+      detection_type: rule.type === 'exclusion' ? 'Exclusion' : 'Rule',
+      asset_type: 'Email',
+      security_domain: 'access',
+      process_names: [],
+      file_paths: [],
+      registry_paths: [],
+      mitre_tactics: mapToMitreTactics(rule.tactics_and_techniques),
+      platforms: ['email'],
+      kql_category: null,
+      kql_tags: [],
+      kql_keywords: [],
+
+      // Sublime-specific fields
+      sublime_attack_types: rule.attack_types || [],
+      sublime_detection_methods: rule.detection_methods || [],
+      sublime_tactics: rule.tactics_and_techniques || [],
+    };
+
+    return detection;
+  } catch {
+    // Skip files that can't be parsed
+    return null;
+  }
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -231,7 +231,7 @@ function getTacticResource(tactic: string): unknown {
  * Get statistics and sample detections for a source type
  */
 function getSourceResource(sourceType: string): unknown {
-  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql'];
+  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'];
   const normalizedSource = sourceType.toLowerCase();
 
   if (!validSources.includes(normalizedSource)) {
@@ -242,7 +242,7 @@ function getSourceResource(sourceType: string): unknown {
   }
 
   const detections = listBySource(
-    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql',
+    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
     50
   );
 

--- a/src/tools/detections/analysis.ts
+++ b/src/tools/detections/analysis.ts
@@ -33,7 +33,7 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter by source type',
         },
         tactic: {
@@ -54,7 +54,7 @@ export const analysisTools = [
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
       const tactic = args.tactic as string | undefined;
       const severity = args.severity as string | undefined;
 
@@ -79,13 +79,13 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter by source type (optional - analyzes all if not specified)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
       const report = analyzeCoverage(sourceType);
       return report;
     },
@@ -104,7 +104,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -112,7 +112,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const threatProfile = args.threat_profile as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
 
       if (!threatProfile) {
         return {
@@ -141,7 +141,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -149,7 +149,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const techniqueId = args.technique_id as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
 
       if (!techniqueId) {
         return {

--- a/src/tools/detections/comparison.ts
+++ b/src/tools/detections/comparison.ts
@@ -26,7 +26,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Optional: filter by source type',
         },
         limit: {
@@ -38,7 +38,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const query = args.query as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
       const limit = (args.limit as number) || 100;
 
       if (!query) {
@@ -174,7 +174,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Optional: filter to specific source',
         },
       },
@@ -182,7 +182,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const pattern = args.pattern as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
 
       if (!pattern) {
         return {
@@ -272,13 +272,13 @@ export const comparisonTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter by source type (optional)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
       const report = analyzeCoverage(sourceType);
 
       // Return minimal data - just percentages

--- a/src/tools/detections/filters.ts
+++ b/src/tools/detections/filters.ts
@@ -26,7 +26,7 @@ export const filterTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Source type to filter by',
         },
         limit: {
@@ -41,7 +41,7 @@ export const filterTools = [
       required: ['source_type'],
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql';
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
       const limit = (args.limit as number) || 100;
       const offset = (args.offset as number) || 0;
 

--- a/src/tools/detections/search.ts
+++ b/src/tools/detections/search.ts
@@ -29,7 +29,7 @@ export const searchTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
           description: 'Filter results by detection source type',
         },
       },

--- a/src/tools/engineering/index.ts
+++ b/src/tools/engineering/index.ts
@@ -44,7 +44,7 @@ const getQueryPatternsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
         description: 'Filter patterns by source type (optional)',
       },
     },
@@ -205,7 +205,7 @@ const findSimilarDetectionsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
         description: 'Filter by source type (optional)',
       },
       limit: {

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -1,17 +1,17 @@
 /**
  * Detection Types
- * Core detection interfaces for Sigma, Splunk ESCU, Elastic, and KQL rules
+ * Core detection interfaces for Sigma, Splunk ESCU, Elastic, KQL, and Sublime rules
  */
 
 /**
- * Unified detection schema - normalized from Sigma, Splunk ESCU, Elastic, and KQL sources
+ * Unified detection schema - normalized from Sigma, Splunk ESCU, Elastic, KQL, and Sublime sources
  */
 export interface Detection {
   id: string;
   name: string;
   description: string;
-  query: string; // detection logic (YAML for Sigma, SPL for Splunk, EQL/KQL for Elastic)
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql';
+  query: string; // detection logic (YAML for Sigma, SPL for Splunk, EQL/KQL for Elastic, MQL for Sublime)
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
   mitre_ids: string[];
   logsource_category: string | null;
   logsource_product: string | null;
@@ -26,13 +26,13 @@ export interface Detection {
   tags: string[];
   file_path: string;
   raw_yaml: string;
-  
+
   // Enhanced fields for better semantic search
   cves: string[];                    // CVE IDs (e.g., CVE-2024-27198)
   analytic_stories: string[];        // Splunk analytic stories
   data_sources: string[];            // Data sources (e.g., Sysmon EventID 1, Windows Security)
-  detection_type: string | null;     // TTP, Anomaly, Hunting, Correlation
-  asset_type: string | null;         // Endpoint, Web Server, Cloud, Network
+  detection_type: string | null;     // TTP, Anomaly, Hunting, Correlation, Rule, Exclusion
+  asset_type: string | null;         // Endpoint, Web Server, Cloud, Network, Email
   security_domain: string | null;    // endpoint, network, cloud, access
   process_names: string[];           // Process names referenced in detection (w3wp.exe, cmd.exe, etc)
   file_paths: string[];              // Interesting file paths referenced (C:\Windows\Temp, etc)
@@ -42,6 +42,11 @@ export interface Detection {
   kql_category: string | null;       // Category derived from path (e.g., "Defender For Endpoint")
   kql_tags: string[];                // Tags/keywords extracted from KQL markdown or metadata
   kql_keywords: string[];            // Lightweight extracted keywords for search
+
+  // Sublime-specific fields
+  sublime_attack_types: string[];    // Sublime attack types (BEC/Fraud, Credential Phishing, etc.)
+  sublime_detection_methods: string[]; // Sublime detection methods (Content analysis, URL analysis, etc.)
+  sublime_tactics: string[];         // Sublime tactics_and_techniques (Evasion, Impersonation: Brand, etc.)
 }
 
 /**
@@ -50,10 +55,30 @@ export interface Detection {
 export interface DetectionSummary {
   id: string;
   name: string;
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql';
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
   mitre_ids: string[];
   severity: string | null;
   mitre_tactics: string[];
+}
+
+/**
+ * Sublime Security rule structure (YAML format with MQL source)
+ * @see https://github.com/sublime-security/sublime-rules
+ */
+export interface SublimeRule {
+  name: string;
+  description: string;
+  type: 'rule' | 'exclusion';
+  source: string; // MQL (Message Query Language) query
+  id?: string;
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  references?: string[];
+  tags?: string[];
+  authors?: Array<{ name?: string; twitter?: string; github?: string; email?: string }>;
+  attack_types?: string[];
+  tactics_and_techniques?: string[];
+  detection_methods?: string[];
+  false_positives?: string[];
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   ElasticRule,
   ElasticThreat,
   ElasticTechnique,
+  SublimeRule,
 } from './detection.js';
 
 // Story types

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -12,6 +12,7 @@ export interface IndexStats {
   splunk_escu: number;
   elastic: number;
   kql: number;
+  sublime: number;
   by_severity: Record<string, number>;
   by_logsource_product: Record<string, number>;
   mitre_coverage: number;


### PR DESCRIPTION
## Summary

Adds [Sublime Security](https://github.com/sublime-security/sublime-rules) as the 5th detection source, bringing email security detection rules written in MQL (Message Query Language) into the unified detection database alongside Sigma, Splunk ESCU, Elastic, and KQL.

Sublime Rules detect email-based threats including BEC/fraud, credential phishing, malware delivery, callback phishing, extortion, and spam. The open-source rule set from `sublime-security/sublime-rules` contains ~900+ detection rules.

## What changed

**New parser** (`src/parsers/sublime.ts`)
- Parses Sublime YAML rules with MQL `source` queries
- Extracts Sublime's own taxonomy: `attack_types`, `tactics_and_techniques`, `detection_methods`
- Best-effort mapping from Sublime tactics to MITRE ATT&CK tactics (e.g., "Social engineering" → initial-access)
- Handles both `rule` and `exclusion` type rules

**Types & schema**
- Added `'sublime'` to the `source_type` union across `Detection`, `DetectionSummary`, and all tool/DB type references
- Added `SublimeRule` interface matching the Sublime YAML schema
- Added 3 new sublime-specific fields to the Detection interface and database: `sublime_attack_types`, `sublime_detection_methods`, `sublime_tactics`
- Updated FTS5 index and sync triggers to include new columns

**Indexing & configuration**
- New `SUBLIME_PATHS` environment variable (comma-separated, same pattern as other sources)
- Indexer discovers `.yml` files in configured paths and parses them with the Sublime parser
- Startup log includes Sublime count

**Tool updates**
- All `source_type` enums in tool schemas updated to include `sublime` (filters, search, analysis, comparison, engineering)
- Stats, coverage analysis, and source comparison functions include Sublime counts
- Resources module accepts `sublime` as a valid source

**Field mapping**

| Sublime Field | Detection Field | Notes |
|---|---|---|
| `name` | `name` | Direct |
| `description` | `description` | Direct |
| `source` (MQL) | `query` | Stored as-is |
| `severity` | `severity` | low/medium/high/critical |
| `id` | `id` | UUID or generated hash |
| `type` | `detection_type` | Rule or Exclusion |
| `attack_types` | `sublime_attack_types` | BEC/Fraud, Credential Phishing, etc. |
| `tactics_and_techniques` | `sublime_tactics` | Evasion, Impersonation: Brand, etc. |
| `detection_methods` | `sublime_detection_methods` | Content analysis, URL analysis, etc. |
| `logsource_category` | `email` | Hardcoded — all Sublime rules are email |
| `asset_type` | `Email` | Hardcoded |

**Documentation**
- README updated with Sublime in all config examples, env vars table, download instructions, detection format docs, schema fields, stats, and example workflows

## Design decisions

- **Sublime-specific fields over MITRE shoehorning**: Sublime uses its own taxonomy (`attack_types`, `tactics_and_techniques`) rather than MITRE T-codes. Instead of forcing these into `mitre_ids`, we preserve the native taxonomy in dedicated fields while doing best-effort MITRE tactic mapping for cross-source analysis.
- **MQL stored as opaque string**: Like SPL and KQL, the MQL source is stored in the `query` field as-is without parsing. It's searchable via FTS5.
- **Both legacy and modular DB updated**: The codebase has a legacy `db.ts` monolith and a modular `db/` directory. Both were updated to ensure the schema, insert, and read operations are consistent.

## How to test

```bash
git clone --depth 1 https://github.com/sublime-security/sublime-rules /tmp/sublime-rules
rm -rf ~/.cache/security-detections-mcp
npm run build
SUBLIME_PATHS=/tmp/sublime-rules/detection-rules node dist/index.js
```

Expected output:
```
[security-detections-mcp] Indexed 941 detections (0 Sigma, 0 Splunk, 0 Elastic, 0 KQL, 941 Sublime)
```

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Full build succeeds (`npm run build`)
- [x] 941 Sublime rules indexed successfully from `sublime-security/sublime-rules`
- [ ] `list_by_source(source_type="sublime")` returns results
- [ ] `search("BEC")` includes Sublime detections
- [ ] `get_stats()` shows Sublime count
- [ ] Existing Sigma/Splunk/Elastic/KQL indexing unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)