### PR TITLE
feat: add CQL Hub (CrowdStrike CQL) as 6th detection source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Security Detections MCP
 
-An MCP (Model Context Protocol) server that lets LLMs query a unified database of **Sigma**, **Splunk ESCU**, **Elastic**, **KQL**, and **Sublime** security detection rules.
+An MCP (Model Context Protocol) server that lets LLMs query a unified database of **Sigma**, **Splunk ESCU**, **Elastic**, **KQL**, **Sublime**, and **CrowdStrike CQL** security detection rules.
 
 > **New here? Start with the [Setup Guide](./SETUP.md)** -- covers macOS, Windows (WSL & native), and Linux step by step.
 
@@ -213,7 +213,7 @@ Claude will:
 - **🆕 Server Instructions** - Built-in usage guide with examples for better LLM understanding
 - **🆕 Structured Errors** - Helpful error messages with suggestions and similar items
 - **🆕 Interactive Tools** - Gap prioritization and sprint planning with form-based input (Cursor 0.42+)
-- **Unified Search** - Query Sigma, Splunk ESCU, Elastic, KQL, and Sublime detections from a single interface
+- **Unified Search** - Query Sigma, Splunk ESCU, Elastic, KQL, Sublime, and CrowdStrike CQL detections from a single interface
 - **Full-Text Search** - SQLite FTS5 powered search across names, descriptions, queries, MITRE tactics, CVEs, process names, and more
 - **MITRE ATT&CK Mapping** - Filter detections by technique ID or tactic
 - **CVE Coverage** - Find detections for specific CVE vulnerabilities
@@ -221,7 +221,7 @@ Claude will:
 - **Analytic Stories** - Query by Splunk analytic story (optional - enhances context)
 - **KQL Categories** - Filter KQL queries by category (Defender For Endpoint, Azure AD, Threat Hunting, etc.)
 - **Auto-Indexing** - Automatically indexes detections on startup from configured paths
-- **Multi-Format Support** - YAML (Sigma, Splunk, Sublime), TOML (Elastic), Markdown (KQL)
+- **Multi-Format Support** - YAML (Sigma, Splunk, Sublime, CrowdStrike CQL), TOML (Elastic), Markdown (KQL)
 - **Logsource Filtering** - Filter Sigma rules by category, product, or service
 - **Severity Filtering** - Filter by criticality level
 
@@ -262,7 +262,8 @@ Add to your MCP config (`~/.cursor/mcp.json` or `.cursor/mcp.json` in your proje
         "ELASTIC_PATHS": "/path/to/detection-rules/rules",
         "STORY_PATHS": "/path/to/security_content/stories",
         "KQL_PATHS": "/path/to/Hunting-Queries-Detection-Rules",
-        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules"
+        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules",
+        "CQL_HUB_PATHS": "/path/to/cql-hub/queries"
       }
     }
   }
@@ -285,7 +286,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "STORY_PATHS": "/Users/you/security_content/stories",
         "KQL_PATHS": "/Users/you/Hunting-Queries-Detection-Rules",
-        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules",
+        "CQL_HUB_PATHS": "/Users/you/cql-hub/queries"
       }
     }
   }
@@ -308,7 +310,8 @@ Add to `~/.vscode/mcp.json`:
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "KQL_PATHS": "/Users/you/kql-bertjanp,/Users/you/kql-jkerai1",
         "STORY_PATHS": "/Users/you/security_content/stories",
-        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules",
+        "CQL_HUB_PATHS": "/Users/you/cql-hub/queries"
       }
     }
   }
@@ -331,7 +334,8 @@ Add to `~/.vscode/mcp.json`:
         "ELASTIC_PATHS": "/Users/you/detection-rules/rules",
         "KQL_PATHS": "/Users/you/kql-bertjanp,/Users/you/kql-jkerai1",
         "STORY_PATHS": "/Users/you/security_content/stories",
-        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules"
+        "SUBLIME_PATHS": "/Users/you/sublime-rules/detection-rules",
+        "CQL_HUB_PATHS": "/Users/you/cql-hub/queries"
       }
     }
   }
@@ -346,6 +350,7 @@ Add to `~/.vscode/mcp.json`:
 | `ELASTIC_PATHS` | Comma-separated paths to Elastic detection rule directories | At least one source required |
 | `KQL_PATHS` | Comma-separated paths to KQL hunting query directories | At least one source required |
 | `SUBLIME_PATHS` | Comma-separated paths to Sublime Security rule directories | At least one source required |
+| `CQL_HUB_PATHS` | Comma-separated paths to CQL Hub (CrowdStrike) query directories | At least one source required |
 | `STORY_PATHS` | Comma-separated paths to Splunk analytic story directories | No (enhances context) |
 
 ## Getting Detection Content
@@ -378,12 +383,16 @@ git clone --depth 1 https://github.com/jkerai1/KQL-Queries.git kql-jkerai1
 git clone --depth 1 --filter=blob:none --sparse https://github.com/sublime-security/sublime-rules.git
 cd sublime-rules && git sparse-checkout set detection-rules && cd ..
 
+# Download CQL Hub CrowdStrike queries (~139+ queries)
+git clone --depth 1 https://github.com/ByteRay-Labs/Query-Hub.git cql-hub
+
 echo "Done! Configure your MCP with these paths:"
 echo "  SIGMA_PATHS: $(pwd)/sigma/rules,$(pwd)/sigma/rules-threat-hunting"
 echo "  SPLUNK_PATHS: $(pwd)/security_content/detections"
 echo "  ELASTIC_PATHS: $(pwd)/detection-rules/rules"
 echo "  KQL_PATHS: $(pwd)/kql-bertjanp,$(pwd)/kql-jkerai1"
 echo "  SUBLIME_PATHS: $(pwd)/sublime-rules/detection-rules"
+echo "  CQL_HUB_PATHS: $(pwd)/cql-hub/queries"
 echo "  STORY_PATHS: $(pwd)/security_content/stories"
 ```
 
@@ -412,6 +421,10 @@ git clone https://github.com/jkerai1/KQL-Queries.git
 # Sublime Security Rules
 git clone https://github.com/sublime-security/sublime-rules.git
 # Use detection-rules/ directory
+
+# CQL Hub (CrowdStrike Query Language)
+git clone https://github.com/ByteRay-Labs/Query-Hub.git
+# Use queries/ directory
 ```
 
 ## 🆕 MCP Resources - Readable Context
@@ -441,7 +454,7 @@ The server provides **autocomplete suggestions** as you type argument values:
 | `process_name` | Process names in your detections (powershell.exe, etc.) |
 | `tactic` | All 14 MITRE tactics |
 | `severity` | informational, low, medium, high, critical |
-| `source_type` | sigma, splunk_escu, elastic, kql, sublime |
+| `source_type` | sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql |
 | `threat_profile` | ransomware, apt, initial-access, persistence, etc. |
 
 This prevents typos and helps discover what values are available in your detection corpus.
@@ -500,7 +513,7 @@ Tool: prioritize_gaps(threat_profile="ransomware")
 | `search(query, limit)` | Full-text search across all detection fields (names, descriptions, queries, CVEs, process names, etc.) |
 | `get_by_id(id)` | Get a single detection by its ID |
 | `list_all(limit, offset)` | Paginated list of all detections |
-| `list_by_source(source_type)` | Filter by `sigma`, `splunk_escu`, `elastic`, `kql`, or `sublime` |
+| `list_by_source(source_type)` | Filter by `sigma`, `splunk_escu`, `elastic`, `kql`, `sublime`, or `crowdstrike_cql` |
 | `get_raw_yaml(id)` | Get the original YAML/TOML/Markdown content |
 | `get_stats()` | Get index statistics |
 | `rebuild_index()` | Force re-index from configured paths |
@@ -851,7 +864,7 @@ Tool: list_by_cve(cve_id="CVE-2024-27198")
 ```
 LLM: "What detections do we have for credential dumping?"
 Tool: search(query="credential dumping", limit=10)
-→ Returns results from Sigma, Splunk, Elastic, KQL, AND Sublime
+→ Returns results from Sigma, Splunk, Elastic, KQL, Sublime, AND CrowdStrike CQL
 ```
 
 #### Find Web Server Attack Detections
@@ -884,6 +897,14 @@ Tool: list_by_source(source_type="sublime")
 → Returns Sublime Security email detection rules for BEC, phishing, malware, etc.
 ```
 
+#### Find CrowdStrike CQL Hunting Queries
+
+```
+LLM: "What CrowdStrike queries do we have for lateral movement?"
+Tool: list_by_source(source_type="crowdstrike_cql")
+→ Returns CQL Hub queries for CrowdStrike NextGen SIEM and Falcon LogScale
+```
+
 #### Search for BloodHound Detections
 
 ```
@@ -894,7 +915,7 @@ Tool: search(query="bloodhound", limit=10)
 
 ## Unified Schema
 
-All detection sources (Sigma, Splunk, Elastic, KQL, Sublime) are normalized to a common schema:
+All detection sources (Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike CQL) are normalized to a common schema:
 
 ### Core Fields
 
@@ -903,8 +924,8 @@ All detection sources (Sigma, Splunk, Elastic, KQL, Sublime) are normalized to a
 | `id` | Unique identifier |
 | `name` | Detection name/title |
 | `description` | What the detection looks for |
-| `query` | Detection logic (Sigma YAML, Splunk SPL, Elastic EQL, KQL, or Sublime MQL) |
-| `source_type` | `sigma`, `splunk_escu`, `elastic`, `kql`, or `sublime` |
+| `query` | Detection logic (Sigma YAML, Splunk SPL, Elastic EQL, KQL, Sublime MQL, or CrowdStrike CQL) |
+| `source_type` | `sigma`, `splunk_escu`, `elastic`, `kql`, `sublime`, or `crowdstrike_cql` |
 | `severity` | Detection severity level |
 | `status` | Rule status (stable, test, experimental, production, etc.) |
 | `author` | Rule author |
@@ -988,6 +1009,14 @@ From [Sublime Security](https://github.com/sublime-security/sublime-rules):
 - Optional: `description`, `severity`, `id`, `references`, `tags`, `authors`, `attack_types`, `tactics_and_techniques`, `detection_methods`, `false_positives`
 - Uses MQL (Message Query Language) for email-specific detection logic
 - Covers BEC/fraud, credential phishing, malware delivery, spam, and more
+
+### CrowdStrike CQL Queries (YAML)
+
+From [CQL Hub](https://github.com/ByteRay-Labs/Query-Hub):
+- Required: `name`, `cql` (CrowdStrike Query Language query)
+- Optional: `description`, `mitre_ids`, `author`, `log_sources`, `tags`, `cs_required_modules`, `explanation`
+- Community-driven detection and hunting queries for CrowdStrike NextGen SIEM and Falcon LogScale
+- Covers endpoint, network, cloud, and identity detection use cases
 
 ### KQL Hunting Queries (Markdown & Raw .kql)
 
@@ -1074,6 +1103,7 @@ SPLUNK_PATHS="./detections/splunk/detections" \
 ELASTIC_PATHS="./detections/elastic/rules" \
 KQL_PATHS="./detections/kql" \
 SUBLIME_PATHS="./detections/sublime-rules/detection-rules" \
+CQL_HUB_PATHS="./detections/cql-hub/queries" \
 STORY_PATHS="./detections/splunk/stories" \
 npm start
 ```
@@ -1089,11 +1119,12 @@ When fully indexed with all sources:
 | Elastic Rules | ~1,500+ |
 | KQL Queries | ~420+ |
 | Sublime Rules | ~900+ |
+| CrowdStrike CQL | ~139+ |
 | Analytic Stories | ~330 |
-| **Total Detections** | **~8,100+** |
+| **Total Detections** | **~8,200+** |
 | **Indexed Patterns** | **10,235+** |
 | **Techniques with Patterns** | **528+** |
-| **Detection Formats** | **5** (Sigma, Splunk, Elastic, KQL, Sublime) |
+| **Detection Formats** | **6** (Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike CQL) |
 | **Total Tools** | **71+** |
 | **MCP Prompts** | **11** |
 | **MCP Resources** | **9 static + 5 templates** |
@@ -1265,7 +1296,8 @@ LLM workflow:
         "SPLUNK_PATHS": "/path/to/security_content/detections",
         "ELASTIC_PATHS": "/path/to/detection-rules/rules",
         "KQL_PATHS": "/path/to/kql-hunting-queries",
-        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules"
+        "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules",
+        "CQL_HUB_PATHS": "/path/to/cql-hub/queries"
       }
     },
     "mitre-attack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,7 +536,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1610,7 +1609,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "security-detections-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Advanced MCP server for security detections with Detection Engineering Intelligence, Knowledge Graph (Tribal Knowledge), Elicitation, and Resource Subscriptions",
   "sigmaSpecVersion": "2.0.0",
   "type": "module",

--- a/src/db.ts
+++ b/src/db.ts
@@ -285,7 +285,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
     mitre_ids: JSON.parse(row.mitre_ids as string || '[]'),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -354,7 +354,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
   return rows.map(rowToDetection);
 }
 
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql', limit: number = 100, offset: number = 0): Detection[] {
   const database = initDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -1365,7 +1365,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
 
 // Get name+ID list filtered by source
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1459,7 +1459,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
 // Get detection names and IDs matching a pattern, grouped by source
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = initDb();
   

--- a/src/db/detections.ts
+++ b/src/db/detections.ts
@@ -21,7 +21,7 @@ export interface ValidationResult {
 }
 
 export interface TechniqueIdFilters {
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
   tactic?: string;
   severity?: string;
 }
@@ -54,7 +54,7 @@ export interface DetectionSuggestion {
 export interface NavigatorLayerOptions {
   name: string;
   description?: string;
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
   tactic?: string;
   severity?: string;
 }
@@ -121,7 +121,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
     mitre_ids: safeJsonParse<string[]>(row.mitre_ids as string, []),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -296,7 +296,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
 /**
  * List detections filtered by source type.
  */
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql', limit: number = 100, offset: number = 0): Detection[] {
   const database = getDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -813,7 +813,7 @@ export function getTechniqueIds(filters: TechniqueIdFilters = {}): string[] {
 /**
  * Analyze coverage by tactic and identify strengths/weaknesses.
  */
-export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'): CoverageReport {
+export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'): CoverageReport {
   const database = getDb();
   
   let countSql = 'SELECT COUNT(DISTINCT id) as count FROM detections';
@@ -896,7 +896,7 @@ export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic'
  */
 export function identifyGaps(
   threatProfile: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
 ): GapAnalysis {
   const targetTechniques = THREAT_PROFILES[threatProfile.toLowerCase()] || THREAT_PROFILES['apt'];
   
@@ -952,7 +952,7 @@ export function identifyGaps(
  */
 export function suggestDetections(
   techniqueId: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
 ): DetectionSuggestion {
   const database = getDb();
   
@@ -1109,7 +1109,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
  * List detections by source with optional name filter, returning lightweight results.
  */
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1202,7 +1202,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
  */
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = getDb();
   
@@ -1246,7 +1246,7 @@ export function countDetectionsBySource(topic: string): Record<string, number> {
   
   const rows = stmt.all(topic) as { source_type: string; count: number }[];
   
-  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0, sublime: 0 };
+  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0, sublime: 0, crowdstrike_cql: 0 };
   for (const row of rows) {
     result[row.source_type] = row.count;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,11 @@ const ELASTIC_PATHS = parsePaths(process.env.ELASTIC_PATHS);
 const STORY_PATHS = parsePaths(process.env.STORY_PATHS);
 const KQL_PATHS = parsePaths(process.env.KQL_PATHS);
 const SUBLIME_PATHS = parsePaths(process.env.SUBLIME_PATHS);
+const CQL_HUB_PATHS = parsePaths(process.env.CQL_HUB_PATHS);
 
 // Auto-index on startup if paths are configured and DB is empty
 function autoIndex(): void {
-  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0) {
+  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0 && CQL_HUB_PATHS.length === 0) {
     return;
   }
   
@@ -41,9 +42,9 @@ function autoIndex(): void {
   
   if (needsIndexing()) {
     console.error('[security-detections-mcp] Auto-indexing detections...');
-    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS);
+    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS, CQL_HUB_PATHS);
     let msg = `[security-detections-mcp] Indexed ${result.total} detections`;
-    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL, ${result.sublime_indexed} Sublime)`;
+    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL, ${result.sublime_indexed} Sublime, ${result.cql_hub_indexed} CrowdStrike CQL)`;
     if (result.stories_indexed > 0) {
       msg += `, ${result.stories_indexed} stories`;
     }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -6,6 +6,7 @@ import { parseStoryFile } from './parsers/story.js';
 import { parseElasticFile } from './parsers/elastic.js';
 import { parseKqlFile, parseRawKqlFile } from './parsers/kql.js';
 import { parseSublimeFile } from './parsers/sublime.js';
+import { parseCqlHubFile } from './parsers/crowdstrike_cql.js';
 import { recreateDb, insertDetection, insertStory, getDetectionCount, initDb } from './db.js';
 
 // Recursively find all YAML files in a directory
@@ -136,6 +137,8 @@ export interface IndexResult {
   kql_failed: number;
   sublime_indexed: number;
   sublime_failed: number;
+  cql_hub_indexed: number;
+  cql_hub_failed: number;
   stories_indexed: number;
   stories_failed: number;
   total: number;
@@ -147,7 +150,8 @@ export function indexDetections(
   storyPaths: string[] = [],
   elasticPaths: string[] = [],
   kqlPaths: string[] = [],
-  sublimePaths: string[] = []
+  sublimePaths: string[] = [],
+  cqlHubPaths: string[] = []
 ): IndexResult {
   // Recreate DB to ensure schema is up to date
   recreateDb();
@@ -163,6 +167,8 @@ export function indexDetections(
   let kql_failed = 0;
   let sublime_indexed = 0;
   let sublime_failed = 0;
+  let cql_hub_indexed = 0;
+  let cql_hub_failed = 0;
   let stories_indexed = 0;
   let stories_failed = 0;
   
@@ -253,6 +259,21 @@ export function indexDetections(
     }
   }
 
+  // Index CQL Hub queries (CrowdStrike Query Language)
+  for (const basePath of cqlHubPaths) {
+    const files = findYamlFiles(basePath);
+
+    for (const file of files) {
+      const detection = parseCqlHubFile(file);
+      if (detection) {
+        insertDetection(detection);
+        cql_hub_indexed++;
+      } else {
+        cql_hub_failed++;
+      }
+    }
+  }
+
   // Index Splunk Analytic Stories (optional)
   for (const basePath of storyPaths) {
     const files = findYamlFiles(basePath);
@@ -279,9 +300,11 @@ export function indexDetections(
     kql_failed,
     sublime_indexed,
     sublime_failed,
+    cql_hub_indexed,
+    cql_hub_failed,
     stories_indexed,
     stories_failed,
-    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed + sublime_indexed,
+    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed + sublime_indexed + cql_hub_indexed,
   };
 }
 

--- a/src/parsers/crowdstrike_cql.ts
+++ b/src/parsers/crowdstrike_cql.ts
@@ -1,0 +1,313 @@
+import { readFileSync } from 'fs';
+import { parse as parseYaml } from 'yaml';
+import { createHash } from 'crypto';
+import type { Detection, CqlHubRule } from '../types.js';
+
+// MITRE technique ID to tactic(s) mapping (top-level techniques only)
+// Some techniques belong to multiple tactics (e.g., T1078 -> initial-access & persistence)
+const TECHNIQUE_TO_TACTICS: Record<string, string[]> = {
+  'T1595': ['reconnaissance'], 'T1592': ['reconnaissance'], 'T1589': ['reconnaissance'],
+  'T1590': ['reconnaissance'], 'T1591': ['reconnaissance'], 'T1598': ['reconnaissance'],
+  'T1597': ['reconnaissance'], 'T1596': ['reconnaissance'], 'T1593': ['reconnaissance'],
+  'T1594': ['reconnaissance'],
+  'T1583': ['resource-development'], 'T1586': ['resource-development'], 'T1584': ['resource-development'],
+  'T1587': ['resource-development'], 'T1585': ['resource-development'], 'T1588': ['resource-development'],
+  'T1608': ['resource-development'],
+  'T1189': ['initial-access'], 'T1190': ['initial-access'],
+  'T1200': ['initial-access'], 'T1566': ['initial-access'],
+  'T1195': ['initial-access'], 'T1199': ['initial-access'],
+  'T1133': ['initial-access', 'persistence'],
+  'T1078': ['initial-access', 'persistence', 'privilege-escalation', 'defense-evasion'],
+  'T1091': ['initial-access', 'lateral-movement'],
+  'T1059': ['execution'], 'T1203': ['execution'], 'T1559': ['execution'],
+  'T1106': ['execution'], 'T1129': ['execution'],
+  'T1204': ['execution'], 'T1047': ['execution'], 'T1569': ['execution'],
+  'T1053': ['execution', 'persistence', 'privilege-escalation'],
+  'T1098': ['persistence'], 'T1197': ['persistence'], 'T1547': ['persistence', 'privilege-escalation'],
+  'T1037': ['persistence'], 'T1136': ['persistence'], 'T1543': ['persistence', 'privilege-escalation'],
+  'T1546': ['persistence', 'privilege-escalation'], 'T1574': ['persistence', 'privilege-escalation'],
+  'T1525': ['persistence'], 'T1556': ['persistence', 'credential-access', 'defense-evasion'],
+  'T1137': ['persistence'], 'T1542': ['persistence', 'defense-evasion'],
+  'T1505': ['persistence'], 'T1205': ['persistence', 'defense-evasion'],
+  'T1548': ['privilege-escalation', 'defense-evasion'], 'T1134': ['privilege-escalation', 'defense-evasion'],
+  'T1068': ['privilege-escalation'], 'T1484': ['privilege-escalation', 'defense-evasion'],
+  'T1611': ['privilege-escalation'],
+  'T1562': ['defense-evasion'], 'T1070': ['defense-evasion'], 'T1202': ['defense-evasion'],
+  'T1036': ['defense-evasion'], 'T1055': ['defense-evasion', 'privilege-escalation'],
+  'T1027': ['defense-evasion'], 'T1218': ['defense-evasion'], 'T1216': ['defense-evasion'],
+  'T1220': ['defense-evasion'], 'T1140': ['defense-evasion'], 'T1112': ['defense-evasion'],
+  'T1564': ['defense-evasion'],
+  'T1003': ['credential-access'], 'T1110': ['credential-access'], 'T1555': ['credential-access'],
+  'T1212': ['credential-access'], 'T1187': ['credential-access'], 'T1606': ['credential-access'],
+  'T1056': ['credential-access', 'collection'], 'T1557': ['credential-access', 'collection'],
+  'T1111': ['credential-access'], 'T1552': ['credential-access'], 'T1558': ['credential-access'],
+  'T1539': ['credential-access'], 'T1528': ['credential-access'], 'T1649': ['credential-access'],
+  'T1087': ['discovery'], 'T1010': ['discovery'], 'T1217': ['discovery'],
+  'T1580': ['discovery'], 'T1538': ['discovery'], 'T1526': ['discovery'],
+  'T1482': ['discovery'], 'T1083': ['discovery'], 'T1046': ['discovery'],
+  'T1135': ['discovery'], 'T1040': ['discovery', 'credential-access'],
+  'T1201': ['discovery'], 'T1120': ['discovery'], 'T1069': ['discovery'],
+  'T1057': ['discovery'], 'T1012': ['discovery'], 'T1018': ['discovery'],
+  'T1518': ['discovery'], 'T1082': ['discovery'], 'T1016': ['discovery'],
+  'T1049': ['discovery'], 'T1033': ['discovery'], 'T1007': ['discovery'],
+  'T1124': ['discovery'],
+  'T1021': ['lateral-movement'], 'T1072': ['lateral-movement'],
+  'T1080': ['lateral-movement'], 'T1550': ['lateral-movement', 'defense-evasion'],
+  'T1563': ['lateral-movement'], 'T1570': ['lateral-movement'],
+  'T1560': ['collection'], 'T1123': ['collection'], 'T1119': ['collection'],
+  'T1115': ['collection'], 'T1530': ['collection'], 'T1602': ['collection'],
+  'T1213': ['collection'], 'T1005': ['collection'], 'T1039': ['collection'],
+  'T1025': ['collection'], 'T1074': ['collection'], 'T1114': ['collection'],
+  'T1113': ['collection'], 'T1125': ['collection'],
+  'T1071': ['command-and-control'], 'T1132': ['command-and-control'],
+  'T1001': ['command-and-control'], 'T1568': ['command-and-control'],
+  'T1573': ['command-and-control'], 'T1008': ['command-and-control'],
+  'T1105': ['command-and-control'], 'T1104': ['command-and-control'],
+  'T1095': ['command-and-control'], 'T1571': ['command-and-control'],
+  'T1572': ['command-and-control'], 'T1090': ['command-and-control'],
+  'T1219': ['command-and-control'], 'T1102': ['command-and-control'],
+  'T1048': ['exfiltration'], 'T1041': ['exfiltration'], 'T1011': ['exfiltration'],
+  'T1052': ['exfiltration'], 'T1567': ['exfiltration'], 'T1029': ['exfiltration'],
+  'T1537': ['exfiltration'],
+  'T1531': ['impact'], 'T1485': ['impact'], 'T1486': ['impact'],
+  'T1565': ['impact'], 'T1491': ['impact'], 'T1561': ['impact'],
+  'T1499': ['impact'], 'T1495': ['impact'], 'T1489': ['impact'],
+  'T1490': ['impact'], 'T1498': ['impact'], 'T1496': ['impact'],
+};
+
+// Generate a stable ID from file path and rule name
+function generateId(filePath: string, name: string): string {
+  const hash = createHash('sha256')
+    .update(`${filePath}:${name}`)
+    .digest('hex')
+    .substring(0, 32);
+  return `crowdstrike-cql-${hash}`;
+}
+
+// Extract MITRE tactics from technique IDs
+function extractMitreTactics(mitreIds: string[]): string[] {
+  const tactics = new Set<string>();
+  for (const id of mitreIds) {
+    // Get the parent technique ID (T1003.001 -> T1003)
+    const parentId = id.split('.')[0];
+    const mapped = TECHNIQUE_TO_TACTICS[parentId];
+    if (mapped) {
+      for (const tactic of mapped) {
+        tactics.add(tactic);
+      }
+    }
+  }
+  return [...tactics];
+}
+
+// Extract process names from CQL query text
+function extractProcessNames(cql: string): string[] {
+  const processNames = new Set<string>();
+
+  // Match .exe references in CQL patterns like FileName=/cmd.exe/, ImageFileName=/\\mimikatz\.exe$/
+  const exeMatches = cql.match(/[\w.-]+\.exe/gi);
+  if (exeMatches) {
+    for (const match of exeMatches) {
+      const name = match.toLowerCase();
+      if (name.length > 4 && !name.includes('*')) {
+        processNames.add(name);
+      }
+    }
+  }
+
+  return [...processNames];
+}
+
+// Extract file paths from CQL query text
+function extractFilePaths(cql: string): string[] {
+  const filePaths = new Set<string>();
+
+  const interestingPaths = [
+    'C:\\Windows\\Temp', 'C:\\Windows\\System32', 'C:\\Windows\\SysWOW64',
+    'C:\\ProgramData', 'C:\\Users\\Public', '\\AppData\\Local\\Temp',
+    '\\AppData\\Roaming',
+  ];
+
+  const cqlLower = cql.toLowerCase();
+  for (const path of interestingPaths) {
+    if (cqlLower.includes(path.toLowerCase())) {
+      filePaths.add(path);
+    }
+  }
+
+  if (cqlLower.includes('\\temp\\') || cqlLower.includes('\\tmp\\')) {
+    filePaths.add('Temp directory');
+  }
+
+  return [...filePaths];
+}
+
+// Extract registry paths from CQL query text
+function extractRegistryPaths(cql: string): string[] {
+  const registryPaths = new Set<string>();
+
+  const cqlLower = cql.toLowerCase();
+  if (cqlLower.includes('hklm') || cqlLower.includes('hkey_local_machine')) {
+    registryPaths.add('HKLM registry');
+  }
+  if (cqlLower.includes('hkcu') || cqlLower.includes('hkey_current_user')) {
+    registryPaths.add('HKCU registry');
+  }
+  if (cqlLower.includes('\\run\\') || cqlLower.includes('\\runonce\\')) {
+    registryPaths.add('Run/RunOnce keys');
+  }
+  if (cqlLower.includes('\\services\\')) {
+    registryPaths.add('Services registry');
+  }
+
+  return [...registryPaths];
+}
+
+// Extract CVE IDs from name and description
+function extractCves(text: string): string[] {
+  const matches = text.match(/CVE-\d{4}-\d+/gi);
+  if (!matches) return [];
+  return [...new Set(matches.map(m => m.toUpperCase()))];
+}
+
+// Infer platforms from CQL query and log_sources
+function extractPlatforms(cql: string, logSources: string[]): string[] {
+  const platforms = new Set<string>();
+
+  // Check event_platform in CQL
+  if (/event_platform\s*=\s*"?Win/i.test(cql)) platforms.add('windows');
+  if (/event_platform\s*=\s*"?Mac/i.test(cql)) platforms.add('macos');
+  if (/event_platform\s*=\s*"?Lin/i.test(cql)) platforms.add('linux');
+
+  // Infer from log_sources
+  for (const src of logSources) {
+    const lower = src.toLowerCase();
+    if (lower === 'endpoint') {
+      // Endpoint could be any OS; only add if no specific platform found
+      if (platforms.size === 0) {
+        platforms.add('windows');
+        platforms.add('linux');
+      }
+    } else if (lower === 'network') {
+      platforms.add('network');
+    } else if (lower === 'cloud' || lower.includes('aws') || lower.includes('azure') || lower.includes('gcp')) {
+      platforms.add('cloud');
+    }
+  }
+
+  return [...platforms];
+}
+
+// Map log_sources to asset type
+function deriveAssetType(logSources: string[]): string | null {
+  if (!logSources || logSources.length === 0) return null;
+  const first = logSources[0].toLowerCase();
+  if (first === 'endpoint') return 'Endpoint';
+  if (first === 'network') return 'Network';
+  if (first === 'cloud' || first.includes('aws') || first.includes('azure') || first.includes('gcp')) return 'Cloud';
+  if (first === 'identity' || first === 'idp') return 'Endpoint';
+  return null;
+}
+
+// Map log_sources to security domain
+function deriveSecurityDomain(logSources: string[]): string | null {
+  if (!logSources || logSources.length === 0) return null;
+  const first = logSources[0].toLowerCase();
+  if (first === 'endpoint') return 'endpoint';
+  if (first === 'network') return 'network';
+  if (first === 'cloud' || first.includes('aws') || first.includes('azure') || first.includes('gcp')) return 'cloud';
+  if (first === 'identity' || first === 'idp') return 'access';
+  return null;
+}
+
+// Map tags to detection type
+function deriveDetectionType(tags: string[]): string | null {
+  for (const tag of tags) {
+    const lower = tag.toLowerCase();
+    if (lower === 'hunting') return 'Hunting';
+    if (lower === 'detection') return 'TTP';
+    if (lower === 'anomaly') return 'Anomaly';
+    if (lower === 'correlation') return 'Correlation';
+  }
+  return null;
+}
+
+export function parseCqlHubFile(filePath: string): Detection | null {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const rule = parseYaml(content) as CqlHubRule;
+
+    // name and cql are required
+    if (!rule.name || !rule.cql) {
+      return null;
+    }
+
+    const id = generateId(filePath, rule.name);
+    const mitreIds = rule.mitre_ids || [];
+    const logSources = rule.log_sources || [];
+    const tags = rule.tags || [];
+    const csModules = rule.cs_required_modules || [];
+
+    // Build description: include explanation if present
+    let description = rule.description || '';
+    if (rule.explanation) {
+      description = description
+        ? `${description}\n\n${rule.explanation}`
+        : rule.explanation;
+    }
+
+    // Combine text fields for CVE extraction
+    const combinedText = `${rule.name} ${rule.description || ''}`;
+
+    // Build enriched tags: include cs_required_modules as prefixed tags
+    const enrichedTags = [
+      ...tags,
+      ...csModules.map(m => `cs_module:${m}`),
+    ];
+
+    const detection: Detection = {
+      id,
+      name: rule.name,
+      description,
+      query: rule.cql,
+      source_type: 'crowdstrike_cql',
+      mitre_ids: mitreIds,
+      logsource_category: logSources.length > 0 ? logSources[0].toLowerCase() : null,
+      logsource_product: 'crowdstrike',
+      logsource_service: 'falcon_logscale',
+      severity: null,
+      status: null,
+      author: rule.author || null,
+      date_created: null,
+      date_modified: null,
+      references: [],
+      falsepositives: [],
+      tags: enrichedTags,
+      file_path: filePath,
+      raw_yaml: content,
+
+      cves: extractCves(combinedText),
+      analytic_stories: [],
+      data_sources: logSources,
+      detection_type: deriveDetectionType(tags),
+      asset_type: deriveAssetType(logSources),
+      security_domain: deriveSecurityDomain(logSources),
+      process_names: extractProcessNames(rule.cql),
+      file_paths: extractFilePaths(rule.cql),
+      registry_paths: extractRegistryPaths(rule.cql),
+      mitre_tactics: extractMitreTactics(mitreIds),
+      platforms: extractPlatforms(rule.cql, logSources),
+      kql_category: null,
+      kql_tags: [],
+      kql_keywords: [],
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
+    };
+
+    return detection;
+  } catch {
+    // Skip files that can't be parsed
+    return null;
+  }
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -231,7 +231,7 @@ function getTacticResource(tactic: string): unknown {
  * Get statistics and sample detections for a source type
  */
 function getSourceResource(sourceType: string): unknown {
-  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'];
+  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'];
   const normalizedSource = sourceType.toLowerCase();
 
   if (!validSources.includes(normalizedSource)) {
@@ -242,7 +242,7 @@ function getSourceResource(sourceType: string): unknown {
   }
 
   const detections = listBySource(
-    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime',
+    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
     50
   );
 

--- a/src/tools/detections/analysis.ts
+++ b/src/tools/detections/analysis.ts
@@ -33,7 +33,7 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter by source type',
         },
         tactic: {
@@ -54,7 +54,7 @@ export const analysisTools = [
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
       const tactic = args.tactic as string | undefined;
       const severity = args.severity as string | undefined;
 
@@ -79,13 +79,13 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter by source type (optional - analyzes all if not specified)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
       const report = analyzeCoverage(sourceType);
       return report;
     },
@@ -104,7 +104,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -112,7 +112,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const threatProfile = args.threat_profile as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
 
       if (!threatProfile) {
         return {
@@ -141,7 +141,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -149,7 +149,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const techniqueId = args.technique_id as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
 
       if (!techniqueId) {
         return {

--- a/src/tools/detections/comparison.ts
+++ b/src/tools/detections/comparison.ts
@@ -26,7 +26,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Optional: filter by source type',
         },
         limit: {
@@ -38,7 +38,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const query = args.query as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
       const limit = (args.limit as number) || 100;
 
       if (!query) {
@@ -174,7 +174,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Optional: filter to specific source',
         },
       },
@@ -182,7 +182,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const pattern = args.pattern as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
 
       if (!pattern) {
         return {
@@ -272,13 +272,13 @@ export const comparisonTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter by source type (optional)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
       const report = analyzeCoverage(sourceType);
 
       // Return minimal data - just percentages

--- a/src/tools/detections/filters.ts
+++ b/src/tools/detections/filters.ts
@@ -26,7 +26,7 @@ export const filterTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Source type to filter by',
         },
         limit: {
@@ -41,7 +41,7 @@ export const filterTools = [
       required: ['source_type'],
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
       const limit = (args.limit as number) || 100;
       const offset = (args.offset as number) || 0;
 

--- a/src/tools/detections/search.ts
+++ b/src/tools/detections/search.ts
@@ -29,7 +29,7 @@ export const searchTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
           description: 'Filter results by detection source type',
         },
       },

--- a/src/tools/engineering/index.ts
+++ b/src/tools/engineering/index.ts
@@ -44,7 +44,7 @@ const getQueryPatternsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
         description: 'Filter patterns by source type (optional)',
       },
     },
@@ -205,7 +205,7 @@ const findSimilarDetectionsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
         description: 'Filter by source type (optional)',
       },
       limit: {

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -1,17 +1,17 @@
 /**
  * Detection Types
- * Core detection interfaces for Sigma, Splunk ESCU, Elastic, KQL, and Sublime rules
+ * Core detection interfaces for Sigma, Splunk ESCU, Elastic, KQL, Sublime, and CrowdStrike CQL rules
  */
 
 /**
- * Unified detection schema - normalized from Sigma, Splunk ESCU, Elastic, KQL, and Sublime sources
+ * Unified detection schema - normalized from Sigma, Splunk ESCU, Elastic, KQL, Sublime, and CrowdStrike CQL sources
  */
 export interface Detection {
   id: string;
   name: string;
   description: string;
   query: string; // detection logic (YAML for Sigma, SPL for Splunk, EQL/KQL for Elastic, MQL for Sublime)
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
   mitre_ids: string[];
   logsource_category: string | null;
   logsource_product: string | null;
@@ -55,7 +55,7 @@ export interface Detection {
 export interface DetectionSummary {
   id: string;
   name: string;
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime';
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
   mitre_ids: string[];
   severity: string | null;
   mitre_tactics: string[];
@@ -193,4 +193,20 @@ export interface ElasticTechnique {
   name?: string;
   reference?: string;
   subtechnique?: ElasticTechnique[];
+}
+
+/**
+ * CQL Hub rule structure (CrowdStrike Query Language)
+ * @see https://github.com/ByteRay-Labs/Query-Hub
+ */
+export interface CqlHubRule {
+  name: string;
+  cql: string;
+  mitre_ids?: string[];
+  description?: string;
+  author?: string;
+  log_sources?: string[];
+  tags?: string[];
+  cs_required_modules?: string[];
+  explanation?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@
  * This module exports all type definitions used throughout the MCP server.
  * Types are organized into logical modules:
  * 
- * - detection: Core detection types (Sigma, Splunk, Elastic, KQL)
+ * - detection: Core detection types (Sigma, Splunk, Elastic, KQL, CrowdStrike CQL)
  * - story: Analytic story and campaign grouping types
  * - stats: Statistics, comparisons, and cached query types
  * - knowledge: Knowledge graph types for agent memory
@@ -22,6 +22,7 @@ export type {
   ElasticThreat,
   ElasticTechnique,
   SublimeRule,
+  CqlHubRule,
 } from './detection.js';
 
 // Story types


### PR DESCRIPTION
## Summary

- Add CrowdStrike Query Language (CQL) as a new detection source, parsing queries from [CQL Hub](https://github.com/ByteRay-Labs/Query-Hub) (MIT license, ~139 community-driven queries for CrowdStrike NextGen SIEM / Falcon LogScale)
- New parser (`src/parsers/crowdstrike_cql.ts`) with MITRE tactic mapping (multi-tactic support), process name extraction, platform inference from CQL query text, and semantic enrichment
- New `CQL_HUB_PATHS` env var, `crowdstrike_cql` source type wired across all tools, enums, database queries, resources, and README

### CQL Hub YAML format (clean, already has MITRE IDs)

```yaml
name: Credential Dumping Detection
mitre_ids: [T1003.001, T1003.002, T1558.003]
description: Detects potential credential dumping...
author: ByteRay GmbH
log_sources: [Endpoint]
tags: [Hunting]
cs_required_modules: [Insight]
cql: |
  #event_simpleName=ProcessRollup2 
  | (CommandLine=/mimikatz|procdump|lsass|sekurlsa/i ...)
explanation: |
  Detailed query explanation...
```

### Files changed (14 files, +447/-61)

| File | Change |
|------|--------|
| `src/parsers/crowdstrike_cql.ts` | **NEW** - Parser with MITRE tactic mapping, process extraction, platform inference |
| `src/types/detection.ts` | Added `CqlHubRule` interface, `'crowdstrike_cql'` to source unions |
| `src/types/index.ts` | Re-exported `CqlHubRule` |
| `src/indexer.ts` | Added `cqlHubPaths` param, indexing loop, counters |
| `src/index.ts` | Added `CQL_HUB_PATHS` env var, wired to indexer |
| `src/db.ts`, `src/db/detections.ts` | Updated all source_type unions |
| `src/tools/detections/*` | Updated all enum arrays and type casts (search, filters, analysis, comparison) |
| `src/tools/engineering/index.ts` | Updated source_type enums |
| `src/resources/index.ts` | Updated valid sources list |
| `README.md` | Added CQL Hub to all config examples, download instructions, stats, schema docs |

## Test plan

- [x] `npm run build` passes cleanly
- [x] Clone [ByteRay-Labs/Query-Hub](https://github.com/ByteRay-Labs/Query-Hub), set `CQL_HUB_PATHS` to the `queries/` directory, verify indexing log shows CrowdStrike CQL count
- [x] `search("mimikatz")` returns CQL Hub credential dumping query
- [x] `list_by_source("crowdstrike_cql")` returns all indexed queries
- [x] `list_by_mitre_technique("T1003")` includes CQL Hub results alongside other sources

https://claude.ai/code/session_013jSwZrdwhEegdZupXCTooY