### PR TITLE
feat: Threat Report Analyzer

### DIFF
--- a/web/app/(app)/reports/[id]/page.tsx
+++ b/web/app/(app)/reports/[id]/page.tsx
@@ -1,0 +1,400 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+interface Technique {
+  id: string;
+  name: string;
+  covered: boolean;
+  detection_count: number;
+  sources: string[];
+}
+
+interface AnalysisResult {
+  summary: string;
+  total_techniques: number;
+  covered_count: number;
+  gap_count: number;
+  coverage_pct: number;
+  gap_techniques: Array<{ id: string; name: string }>;
+  covered_techniques: Array<{ id: string; name: string; detection_count: number; sources: string[] }>;
+  cve_detections: Array<{ cve: string; detection_count: number }>;
+}
+
+interface Report {
+  id: string;
+  title: string;
+  content: string;
+  source_url: string | null;
+  status: string;
+  is_public: boolean;
+  created_at: string;
+  user_id: string | null;
+  extracted_techniques: Technique[] | null;
+  extracted_actors: string[] | null;
+  extracted_iocs: { ips?: string[]; hashes?: string[]; domains?: string[]; cves?: string[] } | null;
+  analysis_result: AnalysisResult | null;
+}
+
+export default async function ReportDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: report } = await supabase
+    .from('threat_reports')
+    .select('*')
+    .eq('id', id)
+    .single() as { data: Report | null };
+
+  if (!report) notFound();
+
+  const analysis = report.analysis_result;
+  const techniques = report.extracted_techniques || [];
+  const actors = report.extracted_actors || [];
+  const iocs = report.extracted_iocs || {};
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-text-dim text-xs font-[family-name:var(--font-mono)] mb-6">
+        <Link href="/reports" className="hover:text-amber transition-colors">Reports</Link>
+        <span>/</span>
+        <span className="text-text truncate max-w-md">{report.title}</span>
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <h1 className="font-[family-name:var(--font-display)] text-2xl tracking-wider text-text-bright">
+            {report.title}
+          </h1>
+          <div className="flex items-center gap-2 shrink-0">
+            <StatusBadge status={report.status} />
+            {report.is_public && (
+              <span className="text-xs px-2 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/30">
+                Public
+              </span>
+            )}
+          </div>
+        </div>
+        {report.source_url && (
+          <a
+            href={report.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-amber hover:text-amber/80 text-sm font-[family-name:var(--font-mono)] underline"
+          >
+            {report.source_url}
+          </a>
+        )}
+        <p className="text-text-dim text-xs mt-2">
+          Analyzed {new Date(report.created_at).toLocaleDateString('en-US', {
+            year: 'numeric', month: 'long', day: 'numeric',
+            hour: '2-digit', minute: '2-digit',
+          })}
+        </p>
+      </div>
+
+      {/* Analyzing state */}
+      {report.status === 'analyzing' && (
+        <div className="bg-card border border-blue-500/30 rounded-[var(--radius-card)] p-8 text-center mb-8">
+          <div className="w-8 h-8 border-2 border-blue-500/30 border-t-blue-400 rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-blue-400 font-medium">Analyzing report...</p>
+          <p className="text-text-dim text-sm mt-1">Extracting techniques, CVEs, and IOCs. This usually takes 10-30 seconds.</p>
+        </div>
+      )}
+
+      {/* Failed state */}
+      {report.status === 'failed' && (
+        <div className="bg-card border border-red-500/30 rounded-[var(--radius-card)] p-8 text-center mb-8">
+          <p className="text-red-400 font-medium">Analysis failed</p>
+          <p className="text-text-dim text-sm mt-1">Something went wrong during analysis. Try submitting the report again.</p>
+          <Link
+            href="/reports/new"
+            className="inline-block mt-4 bg-amber text-bg font-semibold px-5 py-2 rounded-[var(--radius-button)] hover:bg-amber/90 text-sm"
+          >
+            Try Again
+          </Link>
+        </div>
+      )}
+
+      {/* Results */}
+      {report.status === 'complete' && analysis && (
+        <>
+          {/* Summary */}
+          <div className="bg-card border border-amber/20 rounded-[var(--radius-card)] p-5 mb-8">
+            <p className="text-text text-sm leading-relaxed">{analysis.summary}</p>
+          </div>
+
+          {/* Stats Grid */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+            <StatCard label="Techniques" value={analysis.total_techniques} color="text-amber" />
+            <StatCard label="Covered" value={analysis.covered_count} color="text-green" />
+            <StatCard label="Gaps" value={analysis.gap_count} color="text-red" />
+            <StatCard
+              label="Coverage"
+              value={`${analysis.coverage_pct}%`}
+              color={analysis.coverage_pct >= 70 ? 'text-green' : analysis.coverage_pct >= 40 ? 'text-amber' : 'text-red'}
+            />
+          </div>
+
+          {/* Coverage Bar */}
+          {analysis.total_techniques > 0 && (
+            <div className="mb-8">
+              <div className="flex justify-between text-xs text-text-dim mb-2">
+                <span>Detection Coverage</span>
+                <span>{analysis.covered_count} / {analysis.total_techniques}</span>
+              </div>
+              <div className="w-full bg-bg2 rounded-full h-3 border border-border overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    analysis.coverage_pct >= 70 ? 'bg-green' : analysis.coverage_pct >= 40 ? 'bg-amber' : 'bg-red'
+                  }`}
+                  style={{ width: `${analysis.coverage_pct}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Covered Techniques */}
+          {analysis.covered_techniques?.length > 0 && (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-green uppercase mb-4">
+                Covered Techniques ({analysis.covered_count})
+              </h2>
+              <div className="bg-card border border-border rounded-[var(--radius-card)] overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-bg2/50">
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Technique</th>
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Name</th>
+                      <th className="text-center text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Detections</th>
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Sources</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {analysis.covered_techniques.map((t) => (
+                      <tr key={t.id} className="border-b border-border/50 hover:bg-card2/50 transition-colors">
+                        <td className="px-4 py-2.5">
+                          <Link href={`/explore/technique/${t.id}`} className="text-amber hover:underline font-[family-name:var(--font-mono)]">
+                            {t.id}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-2.5 text-text">{t.name}</td>
+                        <td className="px-4 py-2.5 text-center text-green font-semibold">{t.detection_count}</td>
+                        <td className="px-4 py-2.5">
+                          <div className="flex flex-wrap gap-1">
+                            {t.sources.map((s) => (
+                              <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-green/10 text-green border border-green/20">
+                                {s}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Gap Techniques */}
+          {analysis.gap_techniques?.length > 0 && (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-red uppercase mb-4">
+                Gap Techniques ({analysis.gap_count})
+              </h2>
+              <div className="bg-card border border-red-500/20 rounded-[var(--radius-card)] overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-bg2/50">
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Technique</th>
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Name</th>
+                      <th className="text-left text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] px-4 py-3">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {analysis.gap_techniques.map((t) => (
+                      <tr key={t.id} className="border-b border-border/50 hover:bg-card2/50 transition-colors">
+                        <td className="px-4 py-2.5">
+                          <Link href={`/explore/technique/${t.id}`} className="text-amber hover:underline font-[family-name:var(--font-mono)]">
+                            {t.id}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-2.5 text-text">{t.name}</td>
+                        <td className="px-4 py-2.5">
+                          <span className="text-xs px-2 py-0.5 rounded bg-red-500/10 text-red-400 border border-red-500/30">
+                            No Detections
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* CVEs */}
+          {analysis.cve_detections?.length > 0 && (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-amber uppercase mb-4">
+                CVEs ({analysis.cve_detections.length})
+              </h2>
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+                {analysis.cve_detections.map((c) => (
+                  <div key={c.cve} className="bg-card border border-border rounded-[var(--radius-card)] p-3">
+                    <div className="font-[family-name:var(--font-mono)] text-sm text-text-bright">{c.cve}</div>
+                    <div className={`text-xs mt-1 ${c.detection_count > 0 ? 'text-green' : 'text-text-dim'}`}>
+                      {c.detection_count > 0 ? `${c.detection_count} detections` : 'No detections'}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Actors */}
+          {actors.length > 0 && (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-amber uppercase mb-4">
+                Threat Actors ({actors.length})
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {actors.map((actor) => (
+                  <Link
+                    key={actor}
+                    href={`/explore/actor/${encodeURIComponent(actor)}`}
+                    className="bg-card border border-border rounded-[var(--radius-button)] px-3 py-1.5 text-sm text-text-bright hover:border-amber/40 hover:text-amber transition-colors"
+                  >
+                    {actor}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* IOCs */}
+          {(iocs.ips?.length || iocs.hashes?.length || iocs.domains?.length) ? (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-amber uppercase mb-4">
+                IOCs Extracted
+              </h2>
+              <div className="grid gap-4 md:grid-cols-3">
+                {iocs.ips && iocs.ips.length > 0 && (
+                  <div className="bg-card border border-border rounded-[var(--radius-card)] p-4">
+                    <h3 className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-3">
+                      IP Addresses ({iocs.ips.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {iocs.ips.slice(0, 20).map((ip) => (
+                        <div key={ip} className="font-[family-name:var(--font-mono)] text-xs text-text">{ip}</div>
+                      ))}
+                      {iocs.ips.length > 20 && (
+                        <div className="text-text-dim text-xs">... and {iocs.ips.length - 20} more</div>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {iocs.hashes && iocs.hashes.length > 0 && (
+                  <div className="bg-card border border-border rounded-[var(--radius-card)] p-4">
+                    <h3 className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-3">
+                      File Hashes ({iocs.hashes.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {iocs.hashes.slice(0, 20).map((hash) => (
+                        <div key={hash} className="font-[family-name:var(--font-mono)] text-[10px] text-text truncate" title={hash}>{hash}</div>
+                      ))}
+                      {iocs.hashes.length > 20 && (
+                        <div className="text-text-dim text-xs">... and {iocs.hashes.length - 20} more</div>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {iocs.domains && iocs.domains.length > 0 && (
+                  <div className="bg-card border border-border rounded-[var(--radius-card)] p-4">
+                    <h3 className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-3">
+                      Domains ({iocs.domains.length})
+                    </h3>
+                    <div className="space-y-1">
+                      {iocs.domains.slice(0, 20).map((domain) => (
+                        <div key={domain} className="font-[family-name:var(--font-mono)] text-xs text-text">{domain}</div>
+                      ))}
+                      {iocs.domains.length > 20 && (
+                        <div className="text-text-dim text-xs">... and {iocs.domains.length - 20} more</div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+              <p className="text-text-dim text-xs mt-3 italic">
+                IOC-based detection is complementary to behavioral TTP-based detection above.
+              </p>
+            </div>
+          ) : null}
+
+          {/* Technique list from extracted_techniques (if analysis_result techniques differ) */}
+          {techniques.length > 0 && !analysis.covered_techniques?.length && !analysis.gap_techniques?.length && (
+            <div className="mb-8">
+              <h2 className="font-[family-name:var(--font-display)] text-lg tracking-wider text-amber uppercase mb-4">
+                All Techniques ({techniques.length})
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {techniques.map((t) => (
+                  <Link
+                    key={t.id}
+                    href={`/explore/technique/${t.id}`}
+                    className={`px-3 py-1.5 rounded text-sm font-[family-name:var(--font-mono)] border ${
+                      t.covered
+                        ? 'bg-green/10 text-green border-green/30'
+                        : 'bg-red-500/10 text-red-400 border-red-500/30'
+                    } hover:opacity-80 transition-opacity`}
+                  >
+                    {t.id}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Back */}
+      <div className="mt-12 pt-6 border-t border-border">
+        <Link href="/reports" className="text-text-dim hover:text-amber text-sm transition-colors">
+          &larr; Back to Reports
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, color }: { label: string; value: number | string; color: string }) {
+  return (
+    <div className="bg-card border border-border rounded-[var(--radius-card)] p-4 text-center">
+      <div className={`font-[family-name:var(--font-display)] text-3xl ${color}`}>{value}</div>
+      <div className="text-text-dim text-xs font-[family-name:var(--font-mono)] uppercase mt-1">{label}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
+    analyzing: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+    complete: 'bg-green-500/10 text-green-400 border-green-500/30',
+    failed: 'bg-red-500/10 text-red-400 border-red-500/30',
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded border ${styles[status] || styles.pending}`}>
+      {status}
+    </span>
+  );
+}

--- a/web/app/(app)/reports/new/page.tsx
+++ b/web/app/(app)/reports/new/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function NewReportPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<'paste' | 'url'>('url');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [url, setUrl] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+
+    if (mode === 'url' && !url.trim()) {
+      setError('Enter a URL to analyze');
+      return;
+    }
+    if (mode === 'paste' && !content.trim()) {
+      setError('Paste report content to analyze');
+      return;
+    }
+    if (mode === 'url' && !url.match(/^https?:\/\//i)) {
+      setError('URL must start with http:// or https://');
+      return;
+    }
+
+    setAnalyzing(true);
+
+    try {
+      const res = await fetch('/api/reports/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title || undefined,
+          content: mode === 'paste' ? content : undefined,
+          source_url: mode === 'url' ? url.trim() : undefined,
+          is_public: isPublic,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || 'Analysis failed');
+        setAnalyzing(false);
+        return;
+      }
+
+      router.push(`/reports/${data.id}`);
+    } catch {
+      setError('Network error. Please try again.');
+      setAnalyzing(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="font-[family-name:var(--font-display)] text-2xl tracking-wider text-text-bright uppercase mb-2">
+        Analyze Threat Report
+      </h1>
+      <p className="text-text-dim text-sm mb-8">
+        Paste a threat intelligence report or enter a URL. We&apos;ll extract MITRE ATT&amp;CK techniques, CVEs, IOCs, and map them against your detection coverage.
+      </p>
+
+      {/* Mode Toggle */}
+      <div className="flex gap-1 mb-6 bg-card border border-border rounded-[var(--radius-card)] p-1 w-fit">
+        <button
+          onClick={() => setMode('url')}
+          className={`px-4 py-2 rounded-[var(--radius-button)] text-sm font-medium transition-colors ${
+            mode === 'url' ? 'bg-amber/20 text-amber' : 'text-text-dim hover:text-text'
+          }`}
+        >
+          URL
+        </button>
+        <button
+          onClick={() => setMode('paste')}
+          className={`px-4 py-2 rounded-[var(--radius-button)] text-sm font-medium transition-colors ${
+            mode === 'paste' ? 'bg-amber/20 text-amber' : 'text-text-dim hover:text-text'
+          }`}
+        >
+          Paste Text
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Title (optional) */}
+        <div>
+          <label className="block text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-2">
+            Title <span className="text-text-dim/50">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={500}
+            placeholder="e.g., CISA Advisory AA24-131A"
+            className="w-full bg-bg2 border border-border focus:border-amber/50 rounded-[var(--radius-button)] px-4 py-2.5 text-text placeholder:text-text-dim/40 outline-none transition-colors"
+          />
+        </div>
+
+        {/* URL Input */}
+        {mode === 'url' && (
+          <div>
+            <label className="block text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-2">
+              Report URL
+            </label>
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://www.cisa.gov/news-events/cybersecurity-advisories/..."
+              className="w-full bg-bg2 border border-border focus:border-amber/50 rounded-[var(--radius-button)] px-4 py-2.5 text-text placeholder:text-text-dim/40 outline-none transition-colors font-[family-name:var(--font-mono)] text-sm"
+            />
+            <p className="text-text-dim/50 text-xs mt-2">
+              We&apos;ll fetch the page, extract text, and analyze it for techniques, CVEs, and IOCs.
+            </p>
+          </div>
+        )}
+
+        {/* Paste Content */}
+        {mode === 'paste' && (
+          <div>
+            <label className="block text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider mb-2">
+              Report Content
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              maxLength={100000}
+              rows={16}
+              placeholder="Paste the full threat intelligence report here..."
+              className="w-full bg-bg2 border border-border focus:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 text-text placeholder:text-text-dim/40 outline-none transition-colors resize-y text-sm leading-relaxed"
+            />
+            <p className="text-text-dim/50 text-xs mt-1 text-right">
+              {content.length.toLocaleString()} / 100,000
+            </p>
+          </div>
+        )}
+
+        {/* Public toggle */}
+        <label className="flex items-center gap-3 cursor-pointer group">
+          <div className="relative">
+            <input
+              type="checkbox"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+              className="sr-only peer"
+            />
+            <div className="w-10 h-5 bg-border rounded-full peer-checked:bg-amber/60 transition-colors" />
+            <div className="absolute top-0.5 left-0.5 w-4 h-4 bg-text-dim rounded-full peer-checked:translate-x-5 peer-checked:bg-amber transition-all" />
+          </div>
+          <span className="text-sm text-text-dim group-hover:text-text transition-colors">
+            Make this report public (others can see the analysis)
+          </span>
+        </label>
+
+        {/* Error */}
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded-[var(--radius-card)] px-4 py-3 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={analyzing}
+          className="w-full bg-amber text-bg font-semibold py-3 rounded-[var(--radius-button)] hover:bg-amber/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+        >
+          {analyzing ? (
+            <span className="flex items-center justify-center gap-3">
+              <span className="w-4 h-4 border-2 border-bg/30 border-t-bg rounded-full animate-spin" />
+              Analyzing Report...
+            </span>
+          ) : (
+            'Analyze Report'
+          )}
+        </button>
+      </form>
+
+      {/* What we extract */}
+      <div className="mt-12 grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: 'ATT&CK Techniques', desc: 'T-codes + coverage mapping', icon: '&#9876;' },
+          { label: 'CVEs', desc: 'Vulnerability references', icon: '&#128274;' },
+          { label: 'IOCs', desc: 'IPs, hashes, domains', icon: '&#128270;' },
+          { label: 'Actors', desc: 'Threat group attribution', icon: '&#128123;' },
+        ].map((item) => (
+          <div key={item.label} className="bg-card border border-border rounded-[var(--radius-card)] p-4 text-center">
+            <div className="text-2xl mb-2 opacity-60" dangerouslySetInnerHTML={{ __html: item.icon }} />
+            <div className="text-text-bright text-xs font-semibold mb-1">{item.label}</div>
+            <div className="text-text-dim text-[10px]">{item.desc}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/app/(app)/reports/page.tsx
+++ b/web/app/(app)/reports/page.tsx
@@ -1,0 +1,196 @@
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const params = await searchParams;
+  const tab = params.tab || 'mine';
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  let reports: Array<{
+    id: string;
+    title: string;
+    source_url: string | null;
+    status: string;
+    is_public: boolean;
+    created_at: string;
+    user_id: string | null;
+    extracted_techniques: Array<{ id: string }> | null;
+    analysis_result: { coverage_pct?: number; total_techniques?: number; covered_count?: number; gap_count?: number } | null;
+  }> | null = null;
+
+  if (tab === 'public') {
+    const { data } = await supabase
+      .from('threat_reports')
+      .select('id, title, source_url, status, is_public, created_at, user_id, extracted_techniques, analysis_result')
+      .eq('is_public', true)
+      .eq('status', 'complete')
+      .order('created_at', { ascending: false })
+      .limit(50);
+    reports = data;
+  } else {
+    const { data } = await supabase
+      .from('threat_reports')
+      .select('id, title, source_url, status, is_public, created_at, user_id, extracted_techniques, analysis_result')
+      .eq('user_id', user?.id || '')
+      .order('created_at', { ascending: false })
+      .limit(50);
+    reports = data;
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-display)] text-2xl tracking-wider text-text-bright uppercase">
+            Threat Reports
+          </h1>
+          <p className="text-text-dim text-sm mt-1">
+            Upload threat intelligence reports and get instant coverage analysis
+          </p>
+        </div>
+        <Link
+          href="/reports/new"
+          className="bg-amber text-bg font-semibold px-5 py-2.5 rounded-[var(--radius-button)] hover:bg-amber/90 transition-colors text-sm"
+        >
+          + New Report
+        </Link>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 bg-card border border-border rounded-[var(--radius-card)] p-1 w-fit">
+        <Link
+          href="/reports?tab=mine"
+          className={`px-4 py-2 rounded-[var(--radius-button)] text-sm font-medium transition-colors ${
+            tab === 'mine'
+              ? 'bg-amber/20 text-amber'
+              : 'text-text-dim hover:text-text'
+          }`}
+        >
+          My Reports
+        </Link>
+        <Link
+          href="/reports?tab=public"
+          className={`px-4 py-2 rounded-[var(--radius-button)] text-sm font-medium transition-colors ${
+            tab === 'public'
+              ? 'bg-amber/20 text-amber'
+              : 'text-text-dim hover:text-text'
+          }`}
+        >
+          Public Reports
+        </Link>
+      </div>
+
+      {/* Reports Grid */}
+      {!reports?.length ? (
+        <div className="bg-card border border-border rounded-[var(--radius-card)] p-12 text-center">
+          <div className="text-4xl mb-4 opacity-50">&#128196;</div>
+          <h2 className="text-text-bright text-lg mb-2">
+            {tab === 'mine' ? 'No reports yet' : 'No public reports'}
+          </h2>
+          <p className="text-text-dim text-sm mb-6 max-w-md mx-auto">
+            {tab === 'mine'
+              ? 'Upload a threat intelligence report or paste a URL to get instant detection coverage analysis.'
+              : 'No one has shared public reports yet. Be the first!'}
+          </p>
+          {tab === 'mine' && (
+            <Link
+              href="/reports/new"
+              className="bg-amber text-bg font-semibold px-5 py-2.5 rounded-[var(--radius-button)] hover:bg-amber/90 transition-colors text-sm"
+            >
+              Analyze Your First Report
+            </Link>
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {reports.map((report) => {
+            const techniqueCount = report.extracted_techniques?.length || report.analysis_result?.total_techniques || 0;
+            const coveragePct = report.analysis_result?.coverage_pct ?? 0;
+            const coveredCount = report.analysis_result?.covered_count ?? 0;
+            const gapCount = report.analysis_result?.gap_count ?? 0;
+
+            return (
+              <Link
+                key={report.id}
+                href={`/reports/${report.id}`}
+                className="bg-card border border-border rounded-[var(--radius-card)] p-5 hover:border-amber/40 transition-colors group"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-2">
+                      <h3 className="text-text-bright font-semibold truncate group-hover:text-amber transition-colors">
+                        {report.title}
+                      </h3>
+                      <StatusBadge status={report.status} />
+                      {report.is_public && (
+                        <span className="text-xs px-2 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/30">
+                          Public
+                        </span>
+                      )}
+                    </div>
+                    {report.source_url && (
+                      <p className="text-text-dim text-xs font-[family-name:var(--font-mono)] truncate mb-2">
+                        {report.source_url}
+                      </p>
+                    )}
+                    <p className="text-text-dim text-xs">
+                      {new Date(report.created_at).toLocaleDateString('en-US', {
+                        year: 'numeric', month: 'short', day: 'numeric',
+                        hour: '2-digit', minute: '2-digit',
+                      })}
+                    </p>
+                  </div>
+
+                  {report.status === 'complete' && (
+                    <div className="flex gap-6 shrink-0">
+                      <div className="text-center">
+                        <div className="text-xl font-[family-name:var(--font-display)] text-amber">{techniqueCount}</div>
+                        <div className="text-text-dim text-[10px] uppercase font-[family-name:var(--font-mono)]">Techniques</div>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-xl font-[family-name:var(--font-display)] text-green">{coveredCount}</div>
+                        <div className="text-text-dim text-[10px] uppercase font-[family-name:var(--font-mono)]">Covered</div>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-xl font-[family-name:var(--font-display)] text-red">{gapCount}</div>
+                        <div className="text-text-dim text-[10px] uppercase font-[family-name:var(--font-mono)]">Gaps</div>
+                      </div>
+                      <div className="text-center">
+                        <div className={`text-xl font-[family-name:var(--font-display)] ${coveragePct >= 70 ? 'text-green' : coveragePct >= 40 ? 'text-amber' : 'text-red'}`}>
+                          {coveragePct}%
+                        </div>
+                        <div className="text-text-dim text-[10px] uppercase font-[family-name:var(--font-mono)]">Coverage</div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
+    analyzing: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+    complete: 'bg-green-500/10 text-green-400 border-green-500/30',
+    failed: 'bg-red-500/10 text-red-400 border-red-500/30',
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded border ${styles[status] || styles.pending}`}>
+      {status}
+    </span>
+  );
+}

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
 
       // For data-heavy queries, build the response with REAL DATA first,
       // then ask the AI only for analysis/recommendations
-      const { dataReport } = await buildDataDrivenResponse(lastUserMsg);
+      const { dataReport } = await buildDataDrivenResponse(lastUserMsg, user.id);
 
       if (dataReport) {
         // We have structured data — ask AI for brief analysis only
@@ -411,7 +411,7 @@ function cleanDescription(desc: string | null | undefined, maxLen = 300): string
 }
 
 // Build structured data reports directly from DB — no AI hallucination possible
-async function buildDataDrivenResponse(userMessage: string): Promise<{ dataReport: string | null }> {
+async function buildDataDrivenResponse(userMessage: string, userId?: string): Promise<{ dataReport: string | null }> {
   const { createClient } = await import('@supabase/supabase-js');
   const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
   const msg = userMessage.toLowerCase();
@@ -491,12 +491,12 @@ async function buildDataDrivenResponse(userMessage: string): Promise<{ dataRepor
       let report = `## Threat Report Analysis\n\n`;
       report += `**Source:** [${title}](${url})\n\n`;
 
+      // Query coverage for all techniques
+      const techniqueData: Record<string, {name: string; detections: number; sources: string[]}> = {};
+
       // MITRE Techniques found
       if (techniques.length > 0) {
         report += `### MITRE ATT&CK Techniques Found (${techniques.length})\n\n`;
-
-        // Query coverage for all techniques at once
-        const techniqueData: Record<string, {name: string; detections: number; sources: string[]}> = {};
         for (const tid of techniques.slice(0, 20)) {
           const { data: techIntel } = await sb.rpc('get_technique_intelligence', { p_technique_id: tid });
           if (techIntel) {
@@ -550,6 +550,47 @@ async function buildDataDrivenResponse(userMessage: string): Promise<{ dataRepor
         if (hashes.length > 0) report += `**Hashes:** ${hashes.slice(0, 10).join(', ')}\n`;
         report += '\n*Note: IOC-based detection is complementary to behavioral/TTP-based detection above.*\n';
       }
+
+      // Auto-save to threat_reports so it appears in /reports
+      if (userId) {
+        try {
+          const coveredTechs = Object.entries(techniqueData).filter(([, d]) => d.detections > 0);
+          const gapTechs = Object.entries(techniqueData).filter(([, d]) => d.detections === 0);
+          const coveragePctVal = techniques.length > 0 ? Math.round((coveredTechs.length / techniques.length) * 100) : 0;
+
+          await sb.from('threat_reports').insert({
+            user_id: userId,
+            title: title,
+            content: text.substring(0, 100000),
+            source_url: url,
+            status: 'complete',
+            is_public: false,
+            extracted_techniques: techniques.map((tid: string) => ({
+              id: tid,
+              name: techniqueData[tid]?.name || 'Unknown',
+              covered: (techniqueData[tid]?.detections || 0) > 0,
+              detection_count: techniqueData[tid]?.detections || 0,
+              sources: techniqueData[tid]?.sources || [],
+            })),
+            extracted_actors: [],
+            extracted_iocs: { ips, hashes, domains: [], cves },
+            analysis_result: {
+              summary: `Auto-analyzed from chat. ${techniques.length} techniques found, ${coveragePctVal}% coverage.`,
+              total_techniques: techniques.length,
+              covered_count: coveredTechs.length,
+              gap_count: gapTechs.length,
+              coverage_pct: coveragePctVal,
+              gap_techniques: gapTechs.map(([t]) => ({ id: t, name: techniqueData[t]?.name || 'Unknown' })),
+              covered_techniques: coveredTechs.map(([t, d]) => ({ id: t, name: d.name, detection_count: d.detections, sources: d.sources })),
+              cve_detections: cves.map((c: string) => ({ cve: c, detection_count: 0 })),
+            },
+          });
+        } catch (saveErr) {
+          console.error('Failed to auto-save report from chat:', saveErr);
+        }
+      }
+
+      report += `\n---\n*This analysis has been saved to your [Reports](/reports).*\n`;
 
       return { dataReport: report };
     } catch (err) {

--- a/web/app/api/reports/analyze/route.ts
+++ b/web/app/api/reports/analyze/route.ts
@@ -1,0 +1,268 @@
+import { NextRequest } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { title, content, source_url, is_public } = body as {
+      title?: string;
+      content?: string;
+      source_url?: string;
+      is_public?: boolean;
+    };
+
+    // Must have either content or a URL
+    if (!content && !source_url) {
+      return Response.json({ error: 'Provide report content or a URL to analyze' }, { status: 400 });
+    }
+
+    // Validate lengths
+    if (content && content.length > 100000) {
+      return Response.json({ error: 'Content exceeds 100K character limit' }, { status: 400 });
+    }
+    if (title && title.length > 500) {
+      return Response.json({ error: 'Title exceeds 500 character limit' }, { status: 400 });
+    }
+
+    const serviceClient = await createServiceClient();
+
+    // If URL provided but no content, fetch it
+    let reportText = content || '';
+    let reportTitle = title || '';
+    const finalUrl = source_url || null;
+
+    if (source_url && !content) {
+      // SSRF protection
+      try {
+        const parsed = new URL(source_url);
+        const hostname = parsed.hostname.toLowerCase();
+        const BLOCKED_HOSTS = /^(localhost|127\.\d|10\.\d|172\.(1[6-9]|2\d|3[01])\.\d|192\.168\.\d|169\.254\.\d|0\.0\.0\.0|\[::1\]|metadata\.google\.internal)/;
+        if (BLOCKED_HOSTS.test(hostname) || hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+          return Response.json({ error: 'Internal/private URLs cannot be fetched' }, { status: 400 });
+        }
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          return Response.json({ error: 'Only HTTP/HTTPS URLs are supported' }, { status: 400 });
+        }
+      } catch {
+        return Response.json({ error: 'Invalid URL' }, { status: 400 });
+      }
+
+      const response = await fetch(source_url, {
+        headers: { 'User-Agent': 'SecurityDetections/1.0 (Threat Report Analyzer)' },
+        signal: AbortSignal.timeout(15000),
+        redirect: 'follow',
+      });
+
+      const contentLength = response.headers.get('content-length');
+      if (contentLength && parseInt(contentLength) > 5 * 1024 * 1024) {
+        return Response.json({ error: 'Document too large (max 5MB)' }, { status: 400 });
+      }
+
+      if (!response.ok) {
+        return Response.json({ error: `Could not fetch URL (HTTP ${response.status})` }, { status: 400 });
+      }
+
+      const html = await response.text();
+
+      // Extract title from HTML
+      const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+      if (!reportTitle) {
+        reportTitle = titleMatch?.[1]?.trim() || source_url;
+      }
+
+      // Strip HTML to plain text
+      reportText = html
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&[a-z]+;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    if (!reportTitle) {
+      reportTitle = reportText.substring(0, 80).trim() + (reportText.length > 80 ? '...' : '');
+    }
+
+    // Create the report row (status: analyzing)
+    const { data: report, error: insertError } = await serviceClient
+      .from('threat_reports')
+      .insert({
+        user_id: user.id,
+        title: reportTitle,
+        content: reportText.substring(0, 100000),
+        source_url: finalUrl,
+        status: 'analyzing',
+        is_public: is_public || false,
+      })
+      .select('id')
+      .single();
+
+    if (insertError || !report) {
+      console.error('Failed to create report:', insertError);
+      return Response.json({ error: 'Failed to create report' }, { status: 500 });
+    }
+
+    // Run analysis
+    try {
+      const analysis = await analyzeReport(reportText, serviceClient);
+
+      // Update the report with results
+      await serviceClient
+        .from('threat_reports')
+        .update({
+          extracted_techniques: analysis.techniques,
+          extracted_actors: analysis.actors,
+          extracted_iocs: analysis.iocs,
+          analysis_result: analysis.result,
+          status: 'complete',
+        })
+        .eq('id', report.id);
+
+      return Response.json({ id: report.id, status: 'complete' });
+    } catch (err) {
+      console.error('Analysis failed:', err);
+      await serviceClient
+        .from('threat_reports')
+        .update({ status: 'failed' })
+        .eq('id', report.id);
+
+      return Response.json({ id: report.id, status: 'failed', error: 'Analysis failed' }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('Report API error:', error);
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ServiceClient = any;
+
+interface AnalysisResult {
+  techniques: Array<{ id: string; name: string; covered: boolean; detection_count: number; sources: string[] }>;
+  actors: string[];
+  iocs: { ips: string[]; hashes: string[]; domains: string[]; cves: string[] };
+  result: {
+    summary: string;
+    total_techniques: number;
+    covered_count: number;
+    gap_count: number;
+    coverage_pct: number;
+    gap_techniques: Array<{ id: string; name: string }>;
+    covered_techniques: Array<{ id: string; name: string; detection_count: number; sources: string[] }>;
+    cve_detections: Array<{ cve: string; detection_count: number }>;
+  };
+}
+
+async function analyzeReport(text: string, sb: ServiceClient): Promise<AnalysisResult> {
+  // Extract MITRE techniques
+  const techniqueIds = [...new Set(
+    (text.match(/T\d{4}(?:\.\d{3})?/g) || []).map((t: string) => t.toUpperCase())
+  )];
+
+  // Extract CVEs
+  const cves = [...new Set(
+    (text.match(/CVE-\d{4}-\d{4,}/gi) || []).map((c: string) => c.toUpperCase())
+  )];
+
+  // Extract IPs (filter private/loopback)
+  const ips = [...new Set(
+    (text.match(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g) || [])
+      .filter((ip: string) => !ip.startsWith('0.') && !ip.startsWith('127.') && !ip.startsWith('10.') && !ip.startsWith('192.168.') && !ip.startsWith('172.'))
+  )];
+
+  // Extract hashes (MD5 + SHA256)
+  const md5s = [...new Set(text.match(/\b[a-f0-9]{32}\b/gi) || [])];
+  const sha256s = [...new Set(text.match(/\b[a-f0-9]{64}\b/gi) || [])];
+  const hashes = [...md5s, ...sha256s];
+
+  // Extract domains (basic pattern)
+  const domains = [...new Set(
+    (text.match(/\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:com|net|org|io|xyz|top|ru|cn|tk|info|biz|cc|pw|ws)\b/gi) || [])
+      .filter((d: string) => !d.includes('github.com') && !d.includes('microsoft.com') && !d.includes('mitre.org'))
+  )];
+
+  // Extract actor names from text (match known patterns)
+  const actorPatterns = text.match(/\b(?:APT|FIN|UNC|DEV|TEMP)\s*-?\d+\b/gi) || [];
+  const namedActors = text.match(/\b(?:Lazarus|Kimsuky|Turla|Sandworm|Cozy Bear|Fancy Bear|Charming Kitten|Wizard Spider|Evil Corp|Scattered Spider|BlackCat|LockBit|ALPHV|Volt Typhoon|Salt Typhoon|Midnight Blizzard|Star Blizzard|Forest Blizzard|Emerald Sleet|Diamond Sleet|Citrine Sleet|Sapphire Sleet|Ruby Sleet|Jade Sleet|Onyx Sleet|Peach Sandstorm|Mint Sandstorm|Mango Sandstorm|Pumpkin Sandstorm|Cotton Sandstorm|Crimson Sandstorm|Caramel Tsunami|Silk Typhoon|Flax Typhoon|Raspberry Typhoon|Circle Typhoon|Granite Typhoon|Mulberry Typhoon)\b/gi) || [];
+  const actors = [...new Set([...actorPatterns, ...namedActors].map((a: string) => a.trim()))];
+
+  // Query coverage for each technique
+  const techniques: AnalysisResult['techniques'] = [];
+  for (const tid of techniqueIds.slice(0, 30)) {
+    const { data: techIntel } = await sb.rpc('get_technique_intelligence', { p_technique_id: tid }) as {
+      data: { technique_name?: string; total_detections?: number; sources_with_coverage?: string[] } | null;
+    };
+    if (techIntel) {
+      techniques.push({
+        id: tid,
+        name: techIntel.technique_name || 'Unknown',
+        covered: (techIntel.total_detections || 0) > 0,
+        detection_count: techIntel.total_detections || 0,
+        sources: techIntel.sources_with_coverage || [],
+      });
+    } else {
+      techniques.push({ id: tid, name: 'Unknown', covered: false, detection_count: 0, sources: [] });
+    }
+  }
+
+  // Query CVE detections
+  const cveDetections: Array<{ cve: string; detection_count: number }> = [];
+  for (const cve of cves.slice(0, 15)) {
+    const { data: cveData } = await sb.rpc('search_detections_by_filter', {
+      p_filter_type: 'cve',
+      p_filter_value: cve,
+      p_limit: 5,
+    }) as { data: { total?: number } | null };
+    cveDetections.push({ cve, detection_count: cveData?.total || 0 });
+  }
+
+  const coveredTechniques = techniques.filter(t => t.covered);
+  const gapTechniques = techniques.filter(t => !t.covered);
+  const totalTechniques = techniques.length;
+  const coveragePct = totalTechniques > 0 ? Math.round((coveredTechniques.length / totalTechniques) * 100) : 0;
+
+  // Build summary
+  const summaryParts: string[] = [];
+  summaryParts.push(`Analyzed report with ${totalTechniques} MITRE ATT&CK techniques identified.`);
+  summaryParts.push(`Coverage: ${coveredTechniques.length}/${totalTechniques} techniques (${coveragePct}%) have detections.`);
+  if (gapTechniques.length > 0) {
+    summaryParts.push(`${gapTechniques.length} gap techniques need detection development.`);
+  }
+  if (cves.length > 0) summaryParts.push(`${cves.length} CVEs referenced.`);
+  if (actors.length > 0) summaryParts.push(`Threat actors mentioned: ${actors.join(', ')}.`);
+  if (ips.length > 0 || hashes.length > 0 || domains.length > 0) {
+    summaryParts.push(`IOCs extracted: ${ips.length} IPs, ${hashes.length} hashes, ${domains.length} domains.`);
+  }
+
+  return {
+    techniques,
+    actors,
+    iocs: { ips, hashes, domains, cves },
+    result: {
+      summary: summaryParts.join(' '),
+      total_techniques: totalTechniques,
+      covered_count: coveredTechniques.length,
+      gap_count: gapTechniques.length,
+      coverage_pct: coveragePct,
+      gap_techniques: gapTechniques.map(t => ({ id: t.id, name: t.name })),
+      covered_techniques: coveredTechniques.map(t => ({
+        id: t.id,
+        name: t.name,
+        detection_count: t.detection_count,
+        sources: t.sources,
+      })),
+      cve_detections: cveDetections,
+    },
+  };
+}

--- a/web/components/layout/sidebar.tsx
+++ b/web/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ const navItems = [
   { href: '/dashboard', label: 'Dashboard', icon: '&#9638;' },
   { href: '/explore', label: 'Explore', icon: '&#128269;' },
   { href: '/coverage', label: 'Coverage', icon: '&#128200;' },
+  { href: '/reports', label: 'Reports', icon: '&#128196;' },
   { href: '/chat', label: 'Chat', icon: '&#128172;' },
   { href: '/explore/actor', label: 'Actors', icon: '&#128123;' },
   { href: '/coverage/compare', label: 'Compare', icon: '&#8644;' },


### PR DESCRIPTION
## Summary
- Adds `/reports` browse, `/reports/new` upload, `/reports/[id]` detail pages
- `/api/reports/analyze` server-side analysis (URL fetch or paste text)
- Chat URL analyses auto-save to threat_reports table
- Reports nav item added to sidebar

## What it extracts
- MITRE ATT&CK techniques + coverage mapping
- CVEs + detection counts
- IOCs (IPs, hashes, domains)
- Threat actor names