### PR TITLE
feat(web): hosted MCP endpoint with token-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,64 @@
 An MCP (Model Context Protocol) server that lets LLMs query a unified database of **Sigma**, **Splunk ESCU**, **Elastic**, **KQL**, **Sublime**, and **CrowdStrike CQL** security detection rules.
 
 > **New here? Start with the [Setup Guide](./SETUP.md)** -- covers macOS, Windows (WSL & native), and Linux step by step.
+>
+> **Want it hosted? Skip the install entirely: [Hosted MCP Setup Guide](./docs/HOSTED_MCP.md)**
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=security-detections&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlY3VyaXR5LWRldGVjdGlvbnMtbWNwIl0sImVudiI6eyJTSUdNQV9QQVRIUyI6Ii9wYXRoL3RvL3NpZ21hL3J1bGVzLC9wYXRoL3RvL3NpZ21hL3J1bGVzLXRocmVhdC1odW50aW5nIiwiU1BMVU5LX1BBVEhTIjoiL3BhdGgvdG8vc2VjdXJpdHlfY29udGVudC9kZXRlY3Rpb25zIiwiU1RPUllfUEFUSFMiOiIvcGF0aC90by9zZWN1cml0eV9jb250ZW50L3N0b3JpZXMiLCJFTEFTVElDX1BBVEhTIjoiL3BhdGgvdG8vZGV0ZWN0aW9uLXJ1bGVzL3J1bGVzIiwiS1FMX1BBVEhTIjoiL3BhdGgvdG8va3FsLXJ1bGVzIiwiU1VCTElNRV9QQVRIUyI6Ii9wYXRoL3RvL3N1YmxpbWUtcnVsZXMvZGV0ZWN0aW9uLXJ1bGVzIiwiQ1FMX0hVQl9QQVRIUyI6Ii9wYXRoL3RvL2NxbC1odWIvcXVlcmllcyJ9fQ==)
+## Two Ways to Run It
+
+**Local (full power)** — the npm package you're looking at. Runs on your machine, indexes your own detection repos, exposes all 81 tools. You need Node.js and ~10 minutes.
+
+**Hosted (zero setup)** — a Streamable HTTP server at [`detect.michaelhaag.org/api/mcp/http`](https://detect.michaelhaag.org/mcp). Sign up, generate a token, paste one URL into your MCP client. ~25 read-only tools, always in sync with the latest content, 200 calls/day free. Read on for quick-install buttons.
+
+### Install — Local (Cursor)
+
+[![Install Local MCP in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=security-detections&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNlY3VyaXR5LWRldGVjdGlvbnMtbWNwIl0sImVudiI6eyJTSUdNQV9QQVRIUyI6Ii9wYXRoL3RvL3NpZ21hL3J1bGVzLC9wYXRoL3RvL3NpZ21hL3J1bGVzLXRocmVhdC1odW50aW5nIiwiU1BMVU5LX1BBVEhTIjoiL3BhdGgvdG8vc2VjdXJpdHlfY29udGVudC9kZXRlY3Rpb25zIiwiU1RPUllfUEFUSFMiOiIvcGF0aC90by9zZWN1cml0eV9jb250ZW50L3N0b3JpZXMiLCJFTEFTVElDX1BBVEhTIjoiL3BhdGgvdG8vZGV0ZWN0aW9uLXJ1bGVzL3J1bGVzIiwiS1FMX1BBVEhTIjoiL3BhdGgvdG8va3FsLXJ1bGVzIiwiU1VCTElNRV9QQVRIUyI6Ii9wYXRoL3RvL3N1YmxpbWUtcnVsZXMvZGV0ZWN0aW9uLXJ1bGVzIiwiQ1FMX0hVQl9QQVRIUyI6Ii9wYXRoL3RvL2NxbC1odWIvcXVlcmllcyJ9fQ==)
+
+### Install — Hosted (no setup, token required)
+
+1. **Create a token** at [detect.michaelhaag.org/account/tokens](https://detect.michaelhaag.org/account/tokens). Free tier: 200 calls/day, all read-only tools.
+2. **Click the button for your client** — replace `sdmcp_YOUR_TOKEN_HERE` in the resulting config with the token you just generated.
+
+[![Install Hosted MCP in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9odHRwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIHNkbWNwX1lPVVJfVE9LRU5fSEVSRSJ9fQ==)
+[![Install Hosted MCP in VS Code](https://img.shields.io/badge/VS_Code-Install_Hosted_MCP-0078d4?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)
+[![Install Hosted MCP in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Hosted_MCP-24bfa5?style=for-the-badge&logo=visualstudiocode&logoColor=white)](vscode-insiders:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)
+
+**Claude Code** (CLI one-liner):
+
+```bash
+claude mcp add --transport http security-detections \
+  https://detect.michaelhaag.org/api/mcp/http \
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+```
+
+**Claude Desktop** (via [`mcp-remote`](https://github.com/geelen/mcp-remote) — Desktop doesn't speak remote HTTP natively yet):
+
+```json
+{
+  "mcpServers": {
+    "security-detections": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://detect.michaelhaag.org/api/mcp/http",
+        "--header",
+        "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+      ]
+    }
+  }
+}
+```
+
+**OpenAI Codex** (CLI):
+
+```bash
+codex mcp add security-detections \
+  --transport http https://detect.michaelhaag.org/api/mcp/http \
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+```
+
+See the [Hosted MCP Setup Guide](./docs/HOSTED_MCP.md) for the full table of clients, the complete tool inventory, and troubleshooting tips.
 
 ## What's New in 3.2
 

--- a/docs/HOSTED_MCP.md
+++ b/docs/HOSTED_MCP.md
@@ -1,0 +1,281 @@
+# Hosted MCP Setup Guide
+
+A fully managed, public-facing Security Detections MCP server at **[`https://detect.michaelhaag.org/api/mcp/http`](https://detect.michaelhaag.org/api/mcp/http)**. No install, no indexing, always in sync with the latest detection content — just generate a token and point your AI client at the URL.
+
+> **Prefer local?** The npm package is still the full-power option (81 tools, offline, unlimited). See the main [README](../README.md) and [SETUP.md](../SETUP.md). The hosted endpoint is additive — everything in the local package is untouched.
+
+## Table of contents
+
+- [How it works](#how-it-works)
+- [Step 1 — Create a token](#step-1--create-a-token)
+- [Step 2 — Install in your MCP client](#step-2--install-in-your-mcp-client)
+  - [Cursor](#cursor)
+  - [VS Code / VS Code Insiders](#vs-code--vs-code-insiders)
+  - [Claude Code CLI](#claude-code-cli)
+  - [Claude Desktop (via `mcp-remote`)](#claude-desktop-via-mcp-remote)
+  - [OpenAI Codex](#openai-codex)
+  - [Any other MCP client](#any-other-mcp-client)
+- [Verify it works](#verify-it-works)
+- [Tool inventory](#tool-inventory)
+- [Rate limits and quotas](#rate-limits-and-quotas)
+- [Authentication details (RFC 9728 / MCP 2025-11-25)](#authentication-details-rfc-9728--mcp-2025-11-25)
+- [Troubleshooting](#troubleshooting)
+- [What the hosted version does NOT include](#what-the-hosted-version-does-not-include)
+
+## How it works
+
+```
+Your MCP client
+     │
+     │ HTTPS — Authorization: Bearer sdmcp_xxx
+     ▼
+/api/mcp/http  (Next.js route on Vercel, Streamable HTTP, stateless)
+     │
+     │ token hash → atomic rate-limit RPC
+     ▼
+Supabase Postgres (~8,000 detections, full MITRE ATT&CK graph)
+```
+
+- **Transport:** MCP Streamable HTTP (spec **2025-11-25**, the latest), stateless mode — every request is independent, no `Mcp-Session-Id`, no server-sent events, no Redis.
+- **Auth:** Bearer token in the `Authorization` header. Tokens are minted from the web UI, stored server-side as SHA-256 hashes, and validated by a single atomic Postgres RPC that also enforces the per-tier daily quota.
+- **Data:** Supabase-backed. Same ~8,000 detections, 14 tactics, 172 threat actors that power [detect.michaelhaag.org](https://detect.michaelhaag.org). Nightly sync.
+- **Spec compliance:** The server exposes `/.well-known/oauth-protected-resource` (RFC 9728 Protected Resource Metadata) and returns a spec-compliant `WWW-Authenticate: Bearer resource_metadata="..."` header on 401 so MCP clients can auto-discover auth requirements.
+
+## Step 1 — Create a token
+
+1. Visit **[detect.michaelhaag.org/account/tokens](https://detect.michaelhaag.org/account/tokens)** and sign in (email or GitHub via Supabase Auth).
+2. Give your token a name — something like `"Claude Desktop — laptop"` or `"Cursor — work"`.
+3. Click **Generate**.
+4. **Copy the token immediately.** It's shown exactly once. Format: `sdmcp_<32 characters>`.
+
+The full token is never stored in our database — we only keep the SHA-256 hash. If you lose it, revoke it and create a new one.
+
+You can create up to **10 active tokens per account**. Revoke any you no longer need from the same page.
+
+## Step 2 — Install in your MCP client
+
+### Cursor
+
+One-click install (opens Cursor):
+
+**[Install Hosted MCP in Cursor →](https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9odHRwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIHNkbWNwX1lPVVJfVE9LRU5fSEVSRSJ9fQ==)**
+
+After clicking, edit the installed server in **Cursor → Settings → MCP** and replace `sdmcp_YOUR_TOKEN_HERE` with your real token. Or edit `~/.cursor/mcp.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "security-detections": {
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": {
+        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+### VS Code / VS Code Insiders
+
+One-click install (opens VS Code):
+
+- **[Install in VS Code →](vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
+- **[Install in VS Code Insiders →](vscode-insiders:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
+
+After clicking, edit the installed server in VS Code and replace the placeholder token. Or edit your MCP config directly:
+
+```json
+{
+  "servers": {
+    "security-detections": {
+      "type": "http",
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": {
+        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+### Claude Code CLI
+
+```bash
+claude mcp add --transport http security-detections \
+  https://detect.michaelhaag.org/api/mcp/http \
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+```
+
+Verify with `claude mcp list`, then start Claude Code — the tools will be available. `.mcp.json` equivalent:
+
+```json
+{
+  "mcpServers": {
+    "security-detections": {
+      "type": "http",
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": {
+        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop (via `mcp-remote`)
+
+Claude Desktop (the Mac/Windows app) only speaks **stdio** MCP natively, not remote HTTP. Bridge the gap with [`mcp-remote`](https://github.com/geelen/mcp-remote):
+
+**macOS** — edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+**Windows** — edit `%APPDATA%\Claude\claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "security-detections": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://detect.michaelhaag.org/api/mcp/http",
+        "--header",
+        "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+      ]
+    }
+  }
+}
+```
+
+Quit and relaunch Claude Desktop. You should see the detections tools appear in the chat interface.
+
+### OpenAI Codex
+
+Codex CLI and IDE extension support Streamable HTTP remote servers natively.
+
+**CLI one-liner:**
+
+```bash
+codex mcp add security-detections \
+  --transport http https://detect.michaelhaag.org/api/mcp/http \
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+```
+
+**Config file** — `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.security-detections]
+type = "http"
+url = "https://detect.michaelhaag.org/api/mcp/http"
+headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }
+```
+
+### Any other MCP client
+
+Any client that speaks MCP Streamable HTTP (2025-03-26 spec or newer) will work. Give it:
+
+- **URL:** `https://detect.michaelhaag.org/api/mcp/http`
+- **Header:** `Authorization: Bearer sdmcp_YOUR_TOKEN_HERE`
+- **Transport:** Streamable HTTP, stateless (no `Mcp-Session-Id` required)
+- **Protocol version:** The server negotiates up to `2025-11-25`; it accepts `2025-03-26`, `2025-06-18`, `2025-11-25`.
+
+## Verify it works
+
+Before wiring up a client, smoke-test the endpoint with `curl`:
+
+```bash
+# List tools (should return ~25 tools)
+curl -X POST https://detect.michaelhaag.org/api/mcp/http \
+  -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+# Call a tool
+curl -X POST https://detect.michaelhaag.org/api/mcp/http \
+  -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_coverage_summary","arguments":{}}}'
+```
+
+A successful response is JSON-RPC 2.0 with a `result` field. A 401 means your token is missing, wrong, or revoked.
+
+## Tool inventory
+
+The hosted endpoint exposes **~25 read-only tools** — the same schemas as the local npm package, but filtered to the read-only subset (no knowledge graph, no dynamic tables, no autonomous analysis).
+
+| Category | Tools |
+|---|---|
+| **Search & retrieval** | `search`, `get_by_id`, `get_raw_yaml`, `list_all` |
+| **Stats & coverage** | `get_stats`, `get_coverage_summary`, `analyze_coverage`, `identify_gaps`, `get_technique_intelligence`, `get_technique_full`, `compare_sources`, `generate_navigator_layer` |
+| **Filters** | `list_by_source`, `list_by_severity`, `list_by_detection_type`, `list_by_mitre`, `list_by_mitre_tactic`, `list_by_cve`, `list_by_process_name`, `list_by_data_source`, `list_by_analytic_story` |
+| **Threat actors** | `list_actors`, `get_actor_profile`, `analyze_actor_coverage`, `compare_actor_coverage` |
+
+All tools are registered with the modern `server.registerTool()` API and carry spec-compliant annotations:
+
+- `readOnlyHint: true` — no state is mutated, Claude Code won't nag you for permission
+- `destructiveHint: false`
+- `idempotentHint: true`
+- `openWorldHint: false` — closed-world detection corpus
+
+Each tool also includes a `title` (human-readable display name) and a `_meta` block. MCP clients that surface these (Claude Code, Cursor) will show the friendly names in permission prompts and tool pickers.
+
+## Rate limits and quotas
+
+| Tier | Daily calls | How to get it |
+|---|---|---|
+| **Free** | 200 | Default for all new accounts |
+| **Pro** | 5,000 | (Coming soon — Stripe billing not yet live) |
+| **Admin** | 100,000 | Maintainer only |
+
+- Quotas reset at **00:00 UTC**.
+- Rate limiting is **per token**, not per account, so you can segment usage across multiple clients.
+- The current usage is visible on [`/account/tokens`](https://detect.michaelhaag.org/account/tokens) with a live progress bar.
+- Exceeding quota returns JSON-RPC error code `-32003` with a message. Clients will typically surface this as a tool error.
+
+## Authentication details (RFC 9728 / MCP 2025-11-25)
+
+The hosted endpoint is compliant with the current MCP authorization spec:
+
+- **Discovery:** `GET https://detect.michaelhaag.org/.well-known/oauth-protected-resource` returns RFC 9728 Protected Resource Metadata advertising `bearer_methods_supported: ["header"]` and pointing at `/account/tokens` as the token endpoint.
+- **Challenge:** On 401, the server emits `WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://detect.michaelhaag.org/.well-known/oauth-protected-resource"`.
+- **Bearer format:** `Authorization: Bearer sdmcp_<32chars>`. The `Bearer` scheme prefix is recommended but not required — the server also accepts the raw token in the header.
+- **Storage:** Tokens are SHA-256 hashed before storage. The plaintext value exists in the database exactly zero times.
+- **Revocation:** Immediate. Revoke a token via `/account/tokens`, and the next request with it returns `-32001 Token has been revoked`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 Missing or invalid bearer token` | Header missing / malformed / no `sdmcp_` prefix | Check your client config actually sends `Authorization: Bearer sdmcp_...` |
+| `401 Token has been revoked` | Token was revoked via the UI | Generate a new token at `/account/tokens` |
+| `429 Daily quota exceeded` | Over 200 calls today on that token | Wait until 00:00 UTC, or use a different token, or upgrade to Pro |
+| `403 Account blocked` | Account tier is `blocked` | Contact the maintainer |
+| Claude Desktop doesn't see the server | Desktop needs the `mcp-remote` proxy | Use the `mcp-remote` config shown above, not a plain `url` config |
+| Cursor button does nothing | `cursor://` deeplink requires Cursor to be installed | Install Cursor first, then click the button again |
+| VS Code button does nothing | `vscode:` deeplink requires VS Code (or Insiders) open | Make sure the app is running before clicking |
+| Tools appear but all fail | Supabase outage (rare) | Check [status page](https://detect.michaelhaag.org) and retry |
+
+## What the hosted version does NOT include
+
+These tools are **local-only** because they either need per-user state, write to disk, or are destructive:
+
+- Knowledge graph tools (`create_entity`, `create_relation`, `log_decision`, `search_knowledge`, `add_learning`, `get_relevant_decisions`, `get_learnings`)
+- Dynamic tables (`create_table`, `insert_row`, `query_table`, `list_tables`)
+- Query templates (`save_template`, `run_template`, `list_templates`)
+- Autonomous analysis (`auto_analyze_coverage`, `auto_gap_report`, `auto_compare_sources`)
+- Resource subscriptions and elicitation flows
+- Raw YAML / repo write operations
+
+If you need these, run the local npm package — see [SETUP.md](../SETUP.md).
+
+---
+
+## Something broken?
+
+File an issue at [github.com/MHaggis/Security-Detections-MCP/issues](https://github.com/MHaggis/Security-Detections-MCP/issues). Include:
+
+1. Your MCP client (Claude Desktop / Cursor / VS Code / Claude Code / Codex / other)
+2. The JSON-RPC error code you saw (`-32001`, `-32003`, etc.)
+3. The first 8 characters of your token prefix (`sdmcp_ab12cd` — **not** the full token)

--- a/web/app/(app)/account/page.tsx
+++ b/web/app/(app)/account/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import { AccountForm } from './account-form';
 
 export default async function AccountPage() {
@@ -83,6 +84,24 @@ export default async function AccountPage() {
             </a>
           </div>
         )}
+      </div>
+
+      {/* Hosted MCP Tokens */}
+      <div className="bg-card border border-border rounded-[var(--radius-card)] p-6 mb-6">
+        <h2 className="font-[family-name:var(--font-display)] text-xl text-text-bright tracking-wider mb-2">
+          HOSTED MCP TOKENS
+        </h2>
+        <p className="text-text-dim text-sm mb-4">
+          Generate a token to connect your AI assistant (Claude Desktop, Cursor, Claude Code) directly to{' '}
+          <code className="text-amber font-[family-name:var(--font-mono)]">detect.michaelhaag.org/api/mcp/http</code>.
+          No install required.
+        </p>
+        <Link
+          href="/account/tokens"
+          className="inline-block bg-card2 hover:bg-card border border-border-bright text-text-bright font-semibold px-6 py-2 rounded-[var(--radius-button)] transition-colors"
+        >
+          Manage Tokens &rarr;
+        </Link>
       </div>
 
       {/* API Keys */}

--- a/web/app/(app)/account/tokens/page.tsx
+++ b/web/app/(app)/account/tokens/page.tsx
@@ -1,0 +1,128 @@
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { TokensManager } from './tokens-manager';
+
+export const dynamic = 'force-dynamic';
+
+type TokenRow = {
+  id: string;
+  name: string;
+  prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  calls_today: number;
+  calls_reset_at: string;
+  total_calls: number;
+};
+
+export default async function TokensPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login?redirect=/account/tokens');
+
+  // Use service role — the cookie client can also read via RLS, but we
+  // mirror the account/page.tsx pattern for consistency.
+  const service = await createServiceClient();
+  const { data: tokens } = await service
+    .from('mcp_tokens')
+    .select('id, name, prefix, created_at, last_used_at, revoked_at, calls_today, calls_reset_at, total_calls')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  const { data: profile } = await service
+    .from('profiles')
+    .select('tier')
+    .eq('id', user.id)
+    .single();
+
+  const tier = (profile?.tier as string | undefined) ?? 'free';
+  const dailyLimit = tier === 'admin' ? 100000 : tier === 'pro' ? 5000 : 200;
+
+  return (
+    <div className="max-w-3xl mx-auto animate-slide-up">
+      <div className="flex items-center gap-3 mb-2">
+        <Link href="/account" className="text-text-dim hover:text-text text-sm font-[family-name:var(--font-mono)]">
+          &larr; Account
+        </Link>
+      </div>
+      <h1 className="font-[family-name:var(--font-display)] text-4xl text-text-bright tracking-wider mb-2">
+        MCP TOKENS
+      </h1>
+      <p className="text-text-dim text-sm mb-8">
+        Generate tokens to connect your AI client to the hosted Security Detections MCP at{' '}
+        <code className="bg-bg2 px-2 py-0.5 rounded font-[family-name:var(--font-mono)] text-amber">
+          detect.michaelhaag.org/api/mcp/http
+        </code>
+      </p>
+
+      {/* Tier / quota */}
+      <div className="bg-card border border-border rounded-[var(--radius-card)] p-6 mb-6">
+        <h2 className="font-[family-name:var(--font-display)] text-lg text-text-bright tracking-wider mb-3">
+          YOUR QUOTA
+        </h2>
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <div className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider">Tier</div>
+            <div className={`font-[family-name:var(--font-mono)] font-bold ${tier === 'pro' || tier === 'admin' ? 'text-amber' : 'text-text'}`}>
+              {tier.toUpperCase()}
+            </div>
+          </div>
+          <div>
+            <div className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider">Daily Limit</div>
+            <div className="font-[family-name:var(--font-mono)] text-text font-bold">
+              {dailyLimit.toLocaleString()} calls
+            </div>
+          </div>
+          <div>
+            <div className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider">Transport</div>
+            <div className="font-[family-name:var(--font-mono)] text-text">Streamable HTTP</div>
+          </div>
+        </div>
+      </div>
+
+      <TokensManager initialTokens={(tokens as TokenRow[]) ?? []} dailyLimit={dailyLimit} />
+
+      {/* Quick start */}
+      <div className="bg-card border border-border rounded-[var(--radius-card)] p-6 mt-6">
+        <h2 className="font-[family-name:var(--font-display)] text-lg text-text-bright tracking-wider mb-3">
+          CONFIGURE YOUR CLIENT
+        </h2>
+
+        <div className="mb-5">
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Desktop / Claude Code</div>
+          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`{
+  "mcpServers": {
+    "security-detections": {
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": { "Authorization": "Bearer sdmcp_..." }
+    }
+  }
+}`}</pre>
+        </div>
+
+        <div className="mb-5">
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Cursor (~/.cursor/mcp.json)</div>
+          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`{
+  "mcpServers": {
+    "security-detections": {
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": { "Authorization": "Bearer sdmcp_..." }
+    }
+  }
+}`}</pre>
+        </div>
+
+        <div>
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Test with curl</div>
+          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`curl -X POST https://detect.michaelhaag.org/api/mcp/http \\
+  -H "Authorization: Bearer sdmcp_..." \\
+  -H "Accept: application/json, text/event-stream" \\
+  -H "Content-Type: application/json" \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(app)/account/tokens/page.tsx
+++ b/web/app/(app)/account/tokens/page.tsx
@@ -90,28 +90,54 @@ export default async function TokensPage() {
           CONFIGURE YOUR CLIENT
         </h2>
 
+        {/* One-click install buttons */}
+        <div className="grid grid-cols-2 gap-2 mb-5">
+          <a
+            href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9odHRwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIHNkbWNwX1lPVVJfVE9LRU5fSEVSRSJ9fQ=="
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
+          >
+            <span className="text-text-bright font-bold text-xs">Install in Cursor</span>
+            <span className="text-amber text-xs">&rarr;</span>
+          </a>
+          <a
+            href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+            className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
+          >
+            <span className="text-text-bright font-bold text-xs">Install in VS Code</span>
+            <span className="text-amber text-xs">&rarr;</span>
+          </a>
+        </div>
+
         <div className="mb-5">
-          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Desktop / Claude Code</div>
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Code (CLI)</div>
+          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`claude mcp add --transport http security-detections \\
+  https://detect.michaelhaag.org/api/mcp/http \\
+  --header "Authorization: Bearer sdmcp_..."`}</pre>
+        </div>
+
+        <div className="mb-5">
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">
+            Claude Desktop (via mcp-remote)
+          </div>
           <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`{
   "mcpServers": {
     "security-detections": {
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
-      "headers": { "Authorization": "Bearer sdmcp_..." }
+      "command": "npx",
+      "args": ["-y", "mcp-remote",
+        "https://detect.michaelhaag.org/api/mcp/http",
+        "--header", "Authorization: Bearer sdmcp_..."]
     }
   }
 }`}</pre>
         </div>
 
         <div className="mb-5">
-          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Cursor (~/.cursor/mcp.json)</div>
-          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`{
-  "mcpServers": {
-    "security-detections": {
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
-      "headers": { "Authorization": "Bearer sdmcp_..." }
-    }
-  }
-}`}</pre>
+          <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">OpenAI Codex (CLI)</div>
+          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`codex mcp add security-detections \\
+  --transport http https://detect.michaelhaag.org/api/mcp/http \\
+  --header "Authorization: Bearer sdmcp_..."`}</pre>
         </div>
 
         <div>

--- a/web/app/(app)/account/tokens/tokens-manager.tsx
+++ b/web/app/(app)/account/tokens/tokens-manager.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type TokenRow = {
+  id: string;
+  name: string;
+  prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  calls_today: number;
+  calls_reset_at: string;
+  total_calls: number;
+};
+
+interface Props {
+  initialTokens: TokenRow[];
+  dailyLimit: number;
+}
+
+export function TokensManager({ initialTokens, dailyLimit }: Props) {
+  const router = useRouter();
+  const [tokens, setTokens] = useState<TokenRow[]>(initialTokens);
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function createToken() {
+    setError(null);
+    if (!name.trim()) {
+      setError('Token name is required.');
+      return;
+    }
+    setCreating(true);
+    try {
+      const res = await fetch('/api/account/tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to create token');
+        return;
+      }
+      setNewToken(data.token);
+      setTokens((prev) => [
+        {
+          id: data.id,
+          name: data.name,
+          prefix: data.prefix,
+          created_at: data.created_at,
+          last_used_at: null,
+          revoked_at: null,
+          calls_today: 0,
+          calls_reset_at: new Date().toISOString().slice(0, 10),
+          total_calls: 0,
+        },
+        ...prev,
+      ]);
+      setName('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function revokeToken(id: string) {
+    if (!confirm('Revoke this token? Clients using it will lose access immediately.')) return;
+    const res = await fetch(`/api/account/tokens?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (res.ok) {
+      setTokens((prev) => prev.map((t) => (t.id === id ? { ...t, revoked_at: new Date().toISOString() } : t)));
+      router.refresh();
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || 'Failed to revoke');
+    }
+  }
+
+  async function copyToken() {
+    if (!newToken) return;
+    await navigator.clipboard.writeText(newToken);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function dismissNewToken() {
+    setNewToken(null);
+    setCopied(false);
+  }
+
+  return (
+    <div>
+      {/* Create form */}
+      <div className="bg-card border border-border rounded-[var(--radius-card)] p-6 mb-6">
+        <h2 className="font-[family-name:var(--font-display)] text-lg text-text-bright tracking-wider mb-3">
+          CREATE TOKEN
+        </h2>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Claude Desktop — laptop"
+            maxLength={64}
+            className="flex-1 bg-bg2 border border-border focus:border-amber/50 rounded-[var(--radius-button)] px-4 py-2.5 text-text placeholder:text-text-dim/50 outline-none font-[family-name:var(--font-mono)] text-sm"
+          />
+          <button
+            onClick={createToken}
+            disabled={creating || !name.trim()}
+            className="bg-amber hover:bg-amber-dim disabled:opacity-50 text-bg font-bold px-5 py-2 rounded-[var(--radius-button)] transition-colors text-sm"
+          >
+            {creating ? 'Creating...' : 'Generate'}
+          </button>
+        </div>
+        {error && <p className="text-red text-sm mt-2">{error}</p>}
+      </div>
+
+      {/* Reveal dialog (shown once after creation) */}
+      {newToken && (
+        <div className="bg-card border border-green/40 rounded-[var(--radius-card)] p-6 mb-6">
+          <div className="flex items-start justify-between mb-3">
+            <div>
+              <h2 className="font-[family-name:var(--font-display)] text-lg text-green tracking-wider">
+                TOKEN CREATED
+              </h2>
+              <p className="text-text-dim text-xs mt-1">
+                Copy this token now. It will not be shown again — revoke and regenerate if you lose it.
+              </p>
+            </div>
+            <button
+              onClick={dismissNewToken}
+              className="text-text-dim hover:text-text text-xs font-[family-name:var(--font-mono)] uppercase"
+            >
+              Dismiss
+            </button>
+          </div>
+          <div className="bg-bg2 border border-border rounded p-3 font-[family-name:var(--font-mono)] text-xs break-all text-amber">
+            {newToken}
+          </div>
+          <button
+            onClick={copyToken}
+            className="mt-3 bg-green/20 hover:bg-green/30 border border-green/40 text-green font-[family-name:var(--font-mono)] text-xs px-4 py-1.5 rounded transition-colors"
+          >
+            {copied ? 'COPIED!' : 'COPY TO CLIPBOARD'}
+          </button>
+        </div>
+      )}
+
+      {/* Token list */}
+      <div className="bg-card border border-border rounded-[var(--radius-card)] p-6">
+        <h2 className="font-[family-name:var(--font-display)] text-lg text-text-bright tracking-wider mb-4">
+          ACTIVE TOKENS
+        </h2>
+        {tokens.length === 0 ? (
+          <p className="text-text-dim text-sm font-[family-name:var(--font-mono)]">
+            No tokens yet. Generate one above to get started.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {tokens.map((t) => {
+              const revoked = !!t.revoked_at;
+              const pct = Math.min(100, Math.round((t.calls_today / dailyLimit) * 100));
+              return (
+                <div
+                  key={t.id}
+                  className={`border rounded p-4 ${revoked ? 'border-border/40 opacity-50' : 'border-border'}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-[family-name:var(--font-mono)] text-text text-sm font-bold truncate">
+                          {t.name}
+                        </span>
+                        {revoked && (
+                          <span className="text-red text-xs font-[family-name:var(--font-mono)] uppercase">revoked</span>
+                        )}
+                      </div>
+                      <div className="text-text-dim text-xs font-[family-name:var(--font-mono)] mt-1">
+                        {t.prefix}
+                        <span className="opacity-50">...</span>
+                      </div>
+                      <div className="text-text-dim text-xs mt-2 flex gap-4 flex-wrap">
+                        <span>Created {new Date(t.created_at).toLocaleDateString()}</span>
+                        <span>
+                          Last used{' '}
+                          {t.last_used_at ? new Date(t.last_used_at).toLocaleDateString() : 'never'}
+                        </span>
+                        <span>{t.total_calls.toLocaleString()} total calls</span>
+                      </div>
+                    </div>
+                    {!revoked && (
+                      <button
+                        onClick={() => revokeToken(t.id)}
+                        className="text-red hover:text-red-dim text-xs font-[family-name:var(--font-mono)] uppercase px-2 py-1 shrink-0"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </div>
+                  {!revoked && (
+                    <div className="mt-3">
+                      <div className="flex items-center justify-between text-xs text-text-dim mb-1">
+                        <span className="font-[family-name:var(--font-mono)]">TODAY</span>
+                        <span className="font-[family-name:var(--font-mono)]">
+                          {t.calls_today} / {dailyLimit}
+                        </span>
+                      </div>
+                      <div className="h-1.5 bg-bg2 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full ${pct > 90 ? 'bg-red' : pct > 70 ? 'bg-amber' : 'bg-green'}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/api/account/tokens/route.ts
+++ b/web/app/api/account/tokens/route.ts
@@ -1,0 +1,109 @@
+/**
+ * MCP token management API.
+ *
+ *   GET    /api/account/tokens           — list the signed-in user's tokens (metadata only, no secrets)
+ *   POST   /api/account/tokens           — generate a new token (plaintext returned ONCE)
+ *   DELETE /api/account/tokens?id=<uuid> — revoke a token
+ */
+
+import { NextRequest } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { generateToken } from '@/lib/mcp/tokens';
+
+const MAX_TOKENS_PER_USER = 10;
+const MAX_NAME_LENGTH = 64;
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const service = await createServiceClient();
+  const { data, error } = await service
+    .from('mcp_tokens')
+    .select('id, name, prefix, created_at, last_used_at, revoked_at, calls_today, calls_reset_at, total_calls')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+  return Response.json({ tokens: data ?? [] });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let body: { name?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const rawName = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!rawName) return Response.json({ error: 'Token name is required' }, { status: 400 });
+  if (rawName.length > MAX_NAME_LENGTH) {
+    return Response.json({ error: `Token name too long (max ${MAX_NAME_LENGTH} chars)` }, { status: 400 });
+  }
+
+  const service = await createServiceClient();
+
+  // Enforce per-user token cap (active tokens only)
+  const { count, error: countError } = await service
+    .from('mcp_tokens')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+    .is('revoked_at', null);
+  if (countError) return Response.json({ error: countError.message }, { status: 500 });
+  if ((count ?? 0) >= MAX_TOKENS_PER_USER) {
+    return Response.json(
+      { error: `Token limit reached (${MAX_TOKENS_PER_USER} active). Revoke an existing token first.` },
+      { status: 400 },
+    );
+  }
+
+  const { token, hash, prefix } = generateToken();
+  const { data, error } = await service
+    .from('mcp_tokens')
+    .insert({
+      user_id: user.id,
+      token_hash: hash,
+      name: rawName,
+      prefix,
+    })
+    .select('id, name, prefix, created_at')
+    .single();
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  // IMPORTANT: plaintext token returned ONCE here. Not stored anywhere.
+  return Response.json({
+    id: data.id,
+    name: data.name,
+    prefix: data.prefix,
+    created_at: data.created_at,
+    token,
+    hint: 'Copy this token now — it will not be shown again.',
+  });
+}
+
+export async function DELETE(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (!id) return Response.json({ error: 'id query param required' }, { status: 400 });
+
+  const service = await createServiceClient();
+  const { error } = await service
+    .from('mcp_tokens')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('user_id', user.id);
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+  return Response.json({ success: true });
+}

--- a/web/app/api/mcp/[transport]/route.ts
+++ b/web/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * Hosted MCP endpoint — Streamable HTTP, stateless.
+ *
+ * Exposes the read-only detection tools over the MCP Streamable HTTP
+ * transport at /api/mcp/[transport]. Authenticated via bearer tokens
+ * stored in the `mcp_tokens` table (see migration 014_mcp_tokens.sql and
+ * lib/mcp/auth.ts).
+ *
+ * Stateless mode fits Vercel serverless: every request is independent,
+ * no session store, no Redis.
+ */
+
+import { createMcpHandler } from 'mcp-handler';
+import { registerHostedTools } from '@/lib/mcp/tools';
+import { authenticateMcpRequest } from '@/lib/mcp/auth';
+
+// Vercel serverless function configuration.
+// Edge runtime is not compatible with node:crypto + the MCP SDK.
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+const handler = createMcpHandler(
+  (server) => {
+    registerHostedTools(server);
+  },
+  {
+    serverInfo: {
+      name: 'security-detections-hosted',
+      version: '1.0.0',
+    },
+    instructions:
+      'Hosted Security Detections MCP. Read-only access to ~8,000 detections from Sigma, Splunk ESCU, Elastic, KQL, Sublime, and CrowdStrike CQL. Start with get_stats() and get_coverage_summary(), then drill down with search, list_by_mitre, or analyze_actor_coverage.',
+  },
+  {
+    basePath: '/api/mcp',
+    maxDuration: 60,
+    verboseLogs: false,
+  },
+);
+
+async function withAuth(request: Request): Promise<Response> {
+  const auth = await authenticateMcpRequest(request);
+  if (auth.response) return auth.response;
+  // The MCP SDK handler validates and dispatches. We don't need to
+  // propagate auth context into tools because all hosted tools are
+  // read-only over shared public data.
+  return handler(request);
+}
+
+export { withAuth as GET, withAuth as POST, withAuth as DELETE };

--- a/web/app/api/mcp/[transport]/route.ts
+++ b/web/app/api/mcp/[transport]/route.ts
@@ -36,6 +36,11 @@ const handler = createMcpHandler(
     basePath: '/api/mcp',
     maxDuration: 60,
     verboseLogs: false,
+    // Explicit stateless mode per MCP 2025-11-25 Streamable HTTP:
+    // no session cookies, no Mcp-Session-Id emitted, every request
+    // independent. Fits Vercel serverless natively — no Redis needed.
+    sessionIdGenerator: undefined,
+    disableSse: true,
   },
 );
 

--- a/web/app/api/well-known/oauth-protected-resource/route.ts
+++ b/web/app/api/well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,63 @@
+/**
+ * RFC 9728 — OAuth 2.0 Protected Resource Metadata.
+ *
+ * Required by MCP specification 2025-11-25 for token-protected servers.
+ * When /api/mcp returns 401, the WWW-Authenticate header points MCP
+ * clients at https://detect.michaelhaag.org/.well-known/oauth-protected-resource
+ * which is rewritten to this route handler via next.config.ts.
+ *
+ * We don't operate our own OAuth authorization server — tokens are
+ * minted via the web UI and validated directly against Supabase — so
+ * we advertise bearer-in-header as the only supported method and
+ * direct users at our token-generation page.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9728
+ * @see https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function baseUrl(request: Request): string {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  if (forwardedHost) {
+    return `${forwardedProto ?? 'https'}://${forwardedHost}`;
+  }
+  return new URL(request.url).origin;
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const origin = baseUrl(request);
+  const metadata = {
+    resource: `${origin}/api/mcp/http`,
+    authorization_servers: [] as string[],
+    bearer_methods_supported: ['header'],
+    resource_name: 'Security Detections MCP',
+    resource_documentation: `${origin}/mcp`,
+    // MCP-specific hint: non-OAuth clients should send users here to mint a token.
+    token_endpoint: `${origin}/account/tokens`,
+  };
+
+  return new Response(JSON.stringify(metadata, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, MCP-Protocol-Version',
+    },
+  });
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, MCP-Protocol-Version',
+    },
+  });
+}

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -86,7 +86,7 @@ export default function McpSetupPage() {
           </div>
 
           <h1 className="font-[family-name:var(--font-display)] text-5xl md:text-7xl text-text-bright tracking-wide leading-none mb-4">
-            RUN IT <span className="text-amber">LOCALLY</span>
+            RUN IT <span className="text-amber">LOCALLY</span> <span className="text-text-dim">OR</span> <span className="text-green">HOSTED</span>
           </h1>
           <p className="text-text-dim text-lg max-w-2xl mx-auto leading-relaxed">
             The Security Detections MCP server gives your AI assistant direct access to 8,000+ detection rules,
@@ -94,6 +94,12 @@ export default function McpSetupPage() {
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-8">
+            <Link
+              href="/account/tokens"
+              className="bg-green hover:bg-green/80 text-bg font-bold px-8 py-3 rounded-[var(--radius-button)] text-lg transition-colors"
+            >
+              Get Hosted Token
+            </Link>
             <a
               href="https://github.com/MHaggis/Security-Detections-MCP"
               target="_blank"
@@ -114,14 +120,115 @@ export default function McpSetupPage() {
         </div>
       </section>
 
+      {/* Hosted MCP */}
+      <section className="py-16 border-t border-border">
+        <div className="max-w-3xl mx-auto px-6">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <span className="w-2 h-2 rounded-full bg-green animate-pulse-slow" />
+            <span className="font-[family-name:var(--font-mono)] text-xs text-green uppercase tracking-widest">
+              New &middot; Public Beta
+            </span>
+          </div>
+          <h2 className="font-[family-name:var(--font-display)] text-3xl text-text-bright tracking-wider mb-2 text-center">
+            HOSTED MCP — ZERO SETUP
+          </h2>
+          <p className="text-text-dim text-center mb-10 text-sm max-w-2xl mx-auto">
+            Skip the local install. Create an account, generate a token, paste one URL into your MCP client, and start
+            querying. Always in sync with the latest detection content.
+          </p>
+
+          <div className="space-y-0">
+            <Step number={1} title="SIGN IN & GENERATE TOKEN">
+              <p>
+                Sign in with email or GitHub, then visit{' '}
+                <Link href="/account/tokens" className="text-amber hover:underline">
+                  /account/tokens
+                </Link>
+                . Click <span className="text-amber font-bold">Generate</span>, name your token (e.g., &quot;Claude Desktop — laptop&quot;),
+                and copy it — it&apos;s shown exactly once.
+              </p>
+              <div className="bg-card border border-border rounded-[var(--radius-card)] p-4 mt-3">
+                <div className="text-text-dim text-xs font-[family-name:var(--font-mono)] mb-2">FREE TIER</div>
+                <div className="text-text text-sm">200 calls/day &middot; all read-only tools &middot; all 8,000+ detections</div>
+              </div>
+            </Step>
+
+            <Step number={2} title="POINT YOUR MCP CLIENT AT IT">
+              <p>Add this to your client config. No binary to install, no env vars, no local indexing.</p>
+
+              {/* Claude Desktop / Code */}
+              <div className="mt-4">
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Desktop / Claude Code</div>
+                <CodeBlock title="claude_desktop_config.json" lang="json">{`{
+  "mcpServers": {
+    "security-detections": {
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": {
+        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}`}</CodeBlock>
+              </div>
+
+              {/* Cursor */}
+              <div className="mt-4">
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Cursor IDE</div>
+                <CodeBlock title="~/.cursor/mcp.json" lang="json">{`{
+  "mcpServers": {
+    "security-detections": {
+      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "headers": {
+        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}`}</CodeBlock>
+              </div>
+
+              {/* Test with curl */}
+              <div className="mt-4">
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Verify with curl</div>
+                <CodeBlock title="Terminal" lang="bash">{`curl -X POST https://detect.michaelhaag.org/api/mcp/http \\
+  -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \\
+  -H "Accept: application/json, text/event-stream" \\
+  -H "Content-Type: application/json" \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CodeBlock>
+              </div>
+            </Step>
+
+            <Step number={3} title="ASK YOUR AI">
+              <p>Try these prompts in the client you just configured:</p>
+              <div className="space-y-2 mt-2">
+                <div className="bg-card border border-green/20 rounded-[var(--radius-card)] px-4 py-3 font-[family-name:var(--font-mono)] text-green text-sm">
+                  &quot;What&apos;s our coverage against APT29?&quot;
+                </div>
+                <div className="bg-card border border-green/20 rounded-[var(--radius-card)] px-4 py-3 font-[family-name:var(--font-mono)] text-green text-sm">
+                  &quot;Identify gaps for ransomware and suggest missing detections&quot;
+                </div>
+                <div className="bg-card border border-green/20 rounded-[var(--radius-card)] px-4 py-3 font-[family-name:var(--font-mono)] text-green text-sm">
+                  &quot;Generate a Navigator layer for our Sigma coverage&quot;
+                </div>
+              </div>
+            </Step>
+          </div>
+
+          <div className="bg-card border border-border rounded-[var(--radius-card)] p-4 mt-8 text-xs text-text-dim">
+            <span className="text-amber font-bold">~25 tools</span> are exposed on the hosted endpoint: search, list by MITRE
+            technique/tactic/CVE/process, coverage summary, gap analysis, actor profiles, Navigator layer export. Stateful tools (knowledge
+            graph, dynamic tables, custom templates) are local-only for now.
+          </div>
+        </div>
+      </section>
+
       {/* Quick Start */}
       <section className="py-16 border-t border-border">
         <div className="max-w-3xl mx-auto px-6">
           <h2 className="font-[family-name:var(--font-display)] text-3xl text-text-bright tracking-wider mb-2 text-center">
-            QUICK START
+            QUICK START &mdash; LOCAL
           </h2>
           <p className="text-text-dim text-center mb-10 text-sm">
-            Up and running in under 10 minutes. No account required.
+            Full 81-tool experience with your own detection repos. Up and running in under 10 minutes.
           </p>
 
           <div className="space-y-0">

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -153,37 +153,105 @@ export default function McpSetupPage() {
               </div>
             </Step>
 
-            <Step number={2} title="POINT YOUR MCP CLIENT AT IT">
-              <p>Add this to your client config. No binary to install, no env vars, no local indexing.</p>
+            <Step number={2} title="INSTALL IN ONE CLICK">
+              <p>Click the button for your client. Replace <code className="text-amber font-[family-name:var(--font-mono)]">sdmcp_YOUR_TOKEN_HERE</code> with the token you just generated (or paste it when the client prompts).</p>
 
-              {/* Claude Desktop / Code */}
+              {/* One-click install buttons */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+                {/* Cursor */}
+                <a
+                  href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9odHRwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIHNkbWNwX1lPVVJfVE9LRU5fSEVSRSJ9fQ=="
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border-bright hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
+                >
+                  <div>
+                    <div className="text-text-bright font-bold text-sm">Cursor</div>
+                    <div className="text-text-dim text-xs font-[family-name:var(--font-mono)]">Deeplink install</div>
+                  </div>
+                  <span className="text-amber font-[family-name:var(--font-mono)] text-xs">INSTALL &rarr;</span>
+                </a>
+
+                {/* VS Code */}
+                <a
+                  href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+                  className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border-bright hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
+                >
+                  <div>
+                    <div className="text-text-bright font-bold text-sm">VS Code</div>
+                    <div className="text-text-dim text-xs font-[family-name:var(--font-mono)]">Deeplink install</div>
+                  </div>
+                  <span className="text-amber font-[family-name:var(--font-mono)] text-xs">INSTALL &rarr;</span>
+                </a>
+
+                {/* VS Code Insiders */}
+                <a
+                  href="vscode-insiders:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+                  className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
+                >
+                  <div>
+                    <div className="text-text-bright font-bold text-sm">VS Code Insiders</div>
+                    <div className="text-text-dim text-xs font-[family-name:var(--font-mono)]">Deeplink install</div>
+                  </div>
+                  <span className="text-amber font-[family-name:var(--font-mono)] text-xs">INSTALL &rarr;</span>
+                </a>
+
+                {/* Claude Code */}
+                <Link
+                  href="/account/tokens"
+                  className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
+                >
+                  <div>
+                    <div className="text-text-bright font-bold text-sm">Claude Code</div>
+                    <div className="text-text-dim text-xs font-[family-name:var(--font-mono)]">CLI one-liner below</div>
+                  </div>
+                  <span className="text-amber font-[family-name:var(--font-mono)] text-xs">GET TOKEN &rarr;</span>
+                </Link>
+              </div>
+
+              {/* Claude Code CLI */}
+              <div className="mt-6">
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Code (CLI one-liner)</div>
+                <CodeBlock title="Terminal" lang="bash">{`claude mcp add --transport http security-detections \\
+  https://detect.michaelhaag.org/api/mcp/http \\
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
+              </div>
+
+              {/* Claude Desktop via mcp-remote */}
               <div className="mt-4">
-                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Desktop / Claude Code</div>
-                <CodeBlock title="claude_desktop_config.json" lang="json">{`{
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Desktop (via mcp-remote proxy)</div>
+                <p className="text-text-dim text-xs mb-2">
+                  Claude Desktop doesn&apos;t speak remote HTTP natively yet — use <code className="text-amber">mcp-remote</code> to bridge stdio to HTTP.
+                </p>
+                <CodeBlock title="~/Library/Application Support/Claude/claude_desktop_config.json" lang="json">{`{
   "mcpServers": {
     "security-detections": {
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
-      "headers": {
-        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
-      }
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://detect.michaelhaag.org/api/mcp/http",
+        "--header",
+        "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+      ]
     }
   }
 }`}</CodeBlock>
               </div>
 
-              {/* Cursor */}
+              {/* OpenAI Codex */}
               <div className="mt-4">
-                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Cursor IDE</div>
-                <CodeBlock title="~/.cursor/mcp.json" lang="json">{`{
-  "mcpServers": {
-    "security-detections": {
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
-      "headers": {
-        "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
-      }
-    }
-  }
-}`}</CodeBlock>
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">OpenAI Codex</div>
+                <CodeBlock title="Terminal" lang="bash">{`codex mcp add security-detections \\
+  --transport http https://detect.michaelhaag.org/api/mcp/http \\
+  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
+                <p className="text-text-dim text-xs mt-2">
+                  Or edit <code className="text-amber">~/.codex/config.toml</code>:
+                </p>
+                <CodeBlock title="~/.codex/config.toml" lang="toml">{`[mcp_servers.security-detections]
+type = "http"
+url = "https://detect.michaelhaag.org/api/mcp/http"
+headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }`}</CodeBlock>
               </div>
 
               {/* Test with curl */}

--- a/web/lib/mcp/auth.ts
+++ b/web/lib/mcp/auth.ts
@@ -1,0 +1,102 @@
+/**
+ * Bearer-token authentication + rate limiting for the hosted MCP endpoint.
+ *
+ * Called by web/app/api/mcp/[transport]/route.ts on every request. Uses the
+ * atomic `increment_mcp_call` RPC to look up the token, enforce the per-tier
+ * daily quota, and bump the usage counter in a single round-trip.
+ */
+
+import { getServiceClient } from './db';
+import { extractBearer, hashToken } from './tokens';
+
+export interface AuthContext {
+  tokenId: string;
+  userId: string;
+  tier: 'free' | 'pro' | 'admin' | 'blocked';
+  limit: number;
+  remaining: number;
+}
+
+type AuthRpcResult =
+  | { ok: true; token_id: string; user_id: string; tier: AuthContext['tier']; limit: number; remaining: number }
+  | { ok: false; reason: 'invalid_token' | 'revoked' | 'blocked' | 'quota_exceeded'; [k: string]: unknown };
+
+/**
+ * Authenticate a Request for the MCP endpoint.
+ * Returns either { context } on success or { response } with a fully-formed
+ * JSON-RPC error Response to return directly to the client.
+ */
+export async function authenticateMcpRequest(
+  request: Request,
+): Promise<{ context: AuthContext; response?: undefined } | { context?: undefined; response: Response }> {
+  const authHeader =
+    request.headers.get('authorization') ??
+    request.headers.get('Authorization') ??
+    request.headers.get('x-mcp-token');
+
+  const token = extractBearer(authHeader);
+  if (!token) {
+    return { response: errorResponse(401, -32001, 'Missing or invalid bearer token. Generate one at https://detect.michaelhaag.org/account/tokens') };
+  }
+
+  const tokenHash = hashToken(token);
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase.rpc('increment_mcp_call', { p_token_hash: tokenHash });
+
+  if (error) {
+    console.error('[mcp-auth] RPC error:', error.message);
+    return { response: errorResponse(500, -32603, 'Auth backend error') };
+  }
+
+  const result = data as AuthRpcResult | null;
+  if (!result) {
+    return { response: errorResponse(500, -32603, 'Auth backend returned no data') };
+  }
+
+  if (!result.ok) {
+    switch (result.reason) {
+      case 'invalid_token':
+        return { response: errorResponse(401, -32001, 'Invalid token. Check your Authorization header.') };
+      case 'revoked':
+        return { response: errorResponse(401, -32001, 'Token has been revoked. Generate a new one at /account/tokens') };
+      case 'blocked':
+        return { response: errorResponse(403, -32002, 'Account blocked. Contact support.') };
+      case 'quota_exceeded':
+        return {
+          response: errorResponse(
+            429,
+            -32003,
+            `Daily quota exceeded (${result.limit} calls/day). Resets at 00:00 UTC. Upgrade to Pro for higher limits.`,
+          ),
+        };
+      default:
+        return { response: errorResponse(401, -32001, 'Authentication failed') };
+    }
+  }
+
+  return {
+    context: {
+      tokenId: result.token_id,
+      userId: result.user_id,
+      tier: result.tier,
+      limit: result.limit,
+      remaining: result.remaining,
+    },
+  };
+}
+
+function errorResponse(httpStatus: number, jsonRpcCode: number, message: string): Response {
+  const body = {
+    jsonrpc: '2.0',
+    error: { code: jsonRpcCode, message },
+    id: null,
+  };
+  return new Response(JSON.stringify(body), {
+    status: httpStatus,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': 'Bearer realm="mcp"',
+    },
+  });
+}

--- a/web/lib/mcp/auth.ts
+++ b/web/lib/mcp/auth.ts
@@ -4,6 +4,10 @@
  * Called by web/app/api/mcp/[transport]/route.ts on every request. Uses the
  * atomic `increment_mcp_call` RPC to look up the token, enforce the per-tier
  * daily quota, and bump the usage counter in a single round-trip.
+ *
+ * On 401 we emit a `WWW-Authenticate: Bearer resource_metadata="..."` header
+ * as required by MCP spec 2025-11-25 / RFC 9728, pointing at the Protected
+ * Resource Metadata endpoint at /.well-known/oauth-protected-resource.
  */
 
 import { getServiceClient } from './db';
@@ -36,7 +40,14 @@ export async function authenticateMcpRequest(
 
   const token = extractBearer(authHeader);
   if (!token) {
-    return { response: errorResponse(401, -32001, 'Missing or invalid bearer token. Generate one at https://detect.michaelhaag.org/account/tokens') };
+    return {
+      response: errorResponse(
+        request,
+        401,
+        -32001,
+        'Missing or invalid bearer token. Generate one at https://detect.michaelhaag.org/account/tokens',
+      ),
+    };
   }
 
   const tokenHash = hashToken(token);
@@ -46,32 +57,40 @@ export async function authenticateMcpRequest(
 
   if (error) {
     console.error('[mcp-auth] RPC error:', error.message);
-    return { response: errorResponse(500, -32603, 'Auth backend error') };
+    return { response: errorResponse(request, 500, -32603, 'Auth backend error') };
   }
 
   const result = data as AuthRpcResult | null;
   if (!result) {
-    return { response: errorResponse(500, -32603, 'Auth backend returned no data') };
+    return { response: errorResponse(request, 500, -32603, 'Auth backend returned no data') };
   }
 
   if (!result.ok) {
     switch (result.reason) {
       case 'invalid_token':
-        return { response: errorResponse(401, -32001, 'Invalid token. Check your Authorization header.') };
+        return { response: errorResponse(request, 401, -32001, 'Invalid token. Check your Authorization header.') };
       case 'revoked':
-        return { response: errorResponse(401, -32001, 'Token has been revoked. Generate a new one at /account/tokens') };
+        return {
+          response: errorResponse(
+            request,
+            401,
+            -32001,
+            'Token has been revoked. Generate a new one at /account/tokens',
+          ),
+        };
       case 'blocked':
-        return { response: errorResponse(403, -32002, 'Account blocked. Contact support.') };
+        return { response: errorResponse(request, 403, -32002, 'Account blocked. Contact support.') };
       case 'quota_exceeded':
         return {
           response: errorResponse(
+            request,
             429,
             -32003,
             `Daily quota exceeded (${result.limit} calls/day). Resets at 00:00 UTC. Upgrade to Pro for higher limits.`,
           ),
         };
       default:
-        return { response: errorResponse(401, -32001, 'Authentication failed') };
+        return { response: errorResponse(request, 401, -32001, 'Authentication failed') };
     }
   }
 
@@ -86,17 +105,28 @@ export async function authenticateMcpRequest(
   };
 }
 
-function errorResponse(httpStatus: number, jsonRpcCode: number, message: string): Response {
+function resourceMetadataUrl(request: Request): string {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  const origin = forwardedHost
+    ? `${forwardedProto ?? 'https'}://${forwardedHost}`
+    : new URL(request.url).origin;
+  return `${origin}/.well-known/oauth-protected-resource`;
+}
+
+function errorResponse(request: Request, httpStatus: number, jsonRpcCode: number, message: string): Response {
   const body = {
     jsonrpc: '2.0',
     error: { code: jsonRpcCode, message },
     id: null,
   };
-  return new Response(JSON.stringify(body), {
-    status: httpStatus,
-    headers: {
-      'Content-Type': 'application/json',
-      'WWW-Authenticate': 'Bearer realm="mcp"',
-    },
-  });
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  // MCP 2025-11-25 / RFC 9728: on 401 advertise the Protected Resource
+  // Metadata URL so compliant clients can discover auth requirements.
+  if (httpStatus === 401) {
+    headers['WWW-Authenticate'] = `Bearer realm="mcp", resource_metadata="${resourceMetadataUrl(request)}"`;
+  }
+  return new Response(JSON.stringify(body), { status: httpStatus, headers });
 }

--- a/web/lib/mcp/db.ts
+++ b/web/lib/mcp/db.ts
@@ -1,0 +1,359 @@
+/**
+ * Supabase-backed query layer for the hosted MCP server.
+ *
+ * Mirrors the shape of the stdio package's src/db/detections.ts, but reads
+ * from Supabase Postgres instead of the local SQLite cache. Most functions
+ * are thin wrappers around the RPCs defined in migration 002_rls_and_functions.sql.
+ *
+ * All calls use the service-role client because MCP requests authenticate
+ * via bearer tokens (see lib/mcp/auth.ts), not Supabase cookies.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let _serviceClient: SupabaseClient | null = null;
+
+export function getServiceClient(): SupabaseClient {
+  if (_serviceClient) return _serviceClient;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('Supabase env missing: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  }
+  _serviceClient = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return _serviceClient;
+}
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface DetectionRow {
+  id: string;
+  name: string;
+  description: string | null;
+  source_type: string;
+  severity: string | null;
+  mitre_ids: string[];
+  mitre_tactics: string[];
+  detection_type: string | null;
+  data_sources?: string[];
+  query?: string | null;
+}
+
+const DETECTION_LIST_COLUMNS =
+  'id, name, description, source_type, severity, mitre_ids, mitre_tactics, detection_type, data_sources';
+
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'] as const;
+export type SourceType = (typeof SOURCE_TYPES)[number];
+export const ALL_SOURCE_TYPES = SOURCE_TYPES;
+
+// ─── Search & retrieval ───────────────────────────────────────────────────
+
+export async function searchDetections(query: string, limit = 50, sourceType?: string): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+
+  // Build a tsquery string from user input: split on whitespace, AND together
+  const tsquery = query.trim().split(/\s+/).filter(Boolean).join(' & ');
+  if (!tsquery) return [];
+
+  let q = supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .textSearch('search_vector', tsquery, { config: 'english' })
+    .order('name')
+    .limit(Math.min(limit, 100));
+
+  if (sourceType) q = q.eq('source_type', sourceType);
+
+  const { data, error } = await q;
+  if (error) throw new Error(`searchDetections: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function getDetectionById(id: string): Promise<Record<string, unknown> | null> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw new Error(`getDetectionById: ${error.message}`);
+  return data;
+}
+
+export async function getRawYaml(id: string): Promise<string | null> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select('raw_yaml')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw new Error(`getRawYaml: ${error.message}`);
+  return (data?.raw_yaml as string | undefined) ?? null;
+}
+
+export async function listDetections(limit = 100, offset = 0, sourceType?: string): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  let q = supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .order('name')
+    .range(offset, offset + Math.min(limit, 100) - 1);
+  if (sourceType) q = q.eq('source_type', sourceType);
+  const { data, error } = await q;
+  if (error) throw new Error(`listDetections: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+// ─── Stats & coverage ──────────────────────────────────────────────────────
+
+export async function getStats(): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_dashboard_stats');
+  if (error) throw new Error(`getStats: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function getCoverageSummary(): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_coverage_summary');
+  if (error) throw new Error(`getCoverageSummary: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function getThreatProfileGaps(profile: string): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_threat_profile_gaps', { p_profile: profile });
+  if (error) throw new Error(`getThreatProfileGaps: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function getTechniqueIntelligence(techniqueId: string): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_technique_intelligence', { p_technique_id: techniqueId });
+  if (error) throw new Error(`getTechniqueIntelligence: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function getTechniqueFull(techniqueId: string, detectionLimit = 50): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_technique_full', {
+    p_technique_id: techniqueId,
+    p_detection_limit: detectionLimit,
+  });
+  if (error) throw new Error(`getTechniqueFull: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function compareSourcesForTechnique(techniqueId: string): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('compare_sources_for_technique', { p_technique_id: techniqueId });
+  if (error) throw new Error(`compareSourcesForTechnique: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+// ─── Filters ───────────────────────────────────────────────────────────────
+
+export async function listBySource(sourceType: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .eq('source_type', sourceType)
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listBySource: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function listBySeverity(severity: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .eq('severity', severity)
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listBySeverity: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function listByDetectionType(detectionType: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .eq('detection_type', detectionType)
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listByDetectionType: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function listByMitre(techniqueId: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  // Use the junction table so we catch every detection that references the technique.
+  const { data: ids, error: junctionError } = await supabase
+    .from('detection_techniques')
+    .select('detection_id')
+    .eq('technique_id', techniqueId)
+    .limit(500);
+  if (junctionError) throw new Error(`listByMitre (junction): ${junctionError.message}`);
+  if (!ids || ids.length === 0) return [];
+
+  const detectionIds = ids.map((row) => row.detection_id as string);
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .in('id', detectionIds)
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listByMitre: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function listByMitreTactic(tactic: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  // detections.mitre_tactics is JSONB array — use the containment operator
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .contains('mitre_tactics', [tactic])
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listByMitreTactic: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+export async function searchByFilter(
+  filterType: 'process_name' | 'cve' | 'data_source' | 'detection_type' | 'severity',
+  value: string,
+  limit = 20,
+): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('search_detections_by_filter', {
+    p_filter_type: filterType,
+    p_filter_value: value,
+    p_limit: Math.min(limit, 50),
+  });
+  if (error) throw new Error(`searchByFilter: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function listByAnalyticStory(storyName: string, limit = 50): Promise<DetectionRow[]> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('detections')
+    .select(DETECTION_LIST_COLUMNS)
+    .contains('analytic_stories', [storyName])
+    .order('name')
+    .limit(Math.min(limit, 100));
+  if (error) throw new Error(`listByAnalyticStory: ${error.message}`);
+  return (data as DetectionRow[]) ?? [];
+}
+
+// ─── Threat actors ─────────────────────────────────────────────────────────
+
+export async function getActorProfile(actorName: string): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_actor_profile_full', { p_actor_name: actorName });
+  if (error) throw new Error(`getActorProfile: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function getActorIntelligence(actorName: string): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('get_actor_intelligence', { p_actor_name: actorName });
+  if (error) throw new Error(`getActorIntelligence: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function compareActors(actorNames: string[]): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.rpc('compare_actors', { p_actor_names: actorNames });
+  if (error) throw new Error(`compareActors: ${error.message}`);
+  return (data as Record<string, unknown>) ?? {};
+}
+
+export async function listActors(limit = 50, query?: string): Promise<Array<Record<string, unknown>>> {
+  const supabase = getServiceClient();
+  if (query && query.trim()) {
+    const { data, error } = await supabase.rpc('search_actors', { p_query: query });
+    if (error) throw new Error(`listActors (search): ${error.message}`);
+    return ((data as Array<Record<string, unknown>>) ?? []).slice(0, limit);
+  }
+  const { data, error } = await supabase
+    .from('attack_actors')
+    .select('actor_id, name, aliases, description')
+    .order('name')
+    .limit(Math.min(limit, 200));
+  if (error) throw new Error(`listActors: ${error.message}`);
+  return (data as Array<Record<string, unknown>>) ?? [];
+}
+
+// ─── Navigator layer helper ────────────────────────────────────────────────
+// Builds a minimal but valid ATT&CK Navigator layer from covered technique IDs.
+// Mirrors the output shape of the stdio server's generateNavigatorLayer().
+
+export async function generateNavigatorLayer(params: {
+  name?: string;
+  sourceType?: string;
+}): Promise<Record<string, unknown>> {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from('detection_techniques')
+    .select('technique_id, detections!inner(source_type)')
+    .limit(10000);
+
+  if (params.sourceType) {
+    query = query.eq('detections.source_type', params.sourceType);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`generateNavigatorLayer: ${error.message}`);
+
+  const counts = new Map<string, number>();
+  for (const row of (data as Array<{ technique_id: string }>) ?? []) {
+    counts.set(row.technique_id, (counts.get(row.technique_id) ?? 0) + 1);
+  }
+
+  const maxCount = Math.max(1, ...counts.values());
+  const techniques = Array.from(counts.entries()).map(([techniqueID, count]) => ({
+    techniqueID,
+    score: count,
+    color: '',
+    comment: `${count} detection(s)`,
+    enabled: true,
+    metadata: [],
+    showSubtechniques: false,
+  }));
+
+  return {
+    name: params.name || `Security Detections Coverage${params.sourceType ? ` — ${params.sourceType}` : ''}`,
+    versions: { attack: '15', navigator: '5.1.0', layer: '4.5' },
+    domain: 'enterprise-attack',
+    description: `Coverage layer generated from hosted Security Detections MCP (${techniques.length} techniques, max detections per technique: ${maxCount})`,
+    techniques,
+    gradient: {
+      colors: ['#ffffff', '#66bb6a'],
+      minValue: 0,
+      maxValue: maxCount,
+    },
+    legendItems: [],
+    showTacticRowBackground: false,
+    sorting: 0,
+    layout: {
+      layout: 'side',
+      aggregateFunction: 'average',
+      showID: true,
+      showName: true,
+      showAggregateScores: true,
+      countUnscored: false,
+    },
+    hideDisabled: false,
+    selectTechniquesAcrossTactics: true,
+    selectSubtechniquesWithParent: false,
+  };
+}

--- a/web/lib/mcp/tokens.ts
+++ b/web/lib/mcp/tokens.ts
@@ -1,0 +1,49 @@
+/**
+ * MCP token generation, hashing, and prefix helpers.
+ *
+ * Tokens look like `sdmcp_<base62>` where the payload is 32 random bytes.
+ * Only the sha256(token) is stored server-side; the plaintext is returned
+ * to the user exactly once at creation time.
+ */
+
+import { createHash, randomBytes } from 'crypto';
+
+export const TOKEN_PREFIX = 'sdmcp_';
+const RAW_BYTES = 32;
+
+// URL-safe base62-ish alphabet (no padding, no ambiguous chars).
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789';
+
+function encodeBytes(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) {
+    out += ALPHABET[byte % ALPHABET.length];
+  }
+  return out;
+}
+
+export function generateToken(): { token: string; hash: string; prefix: string } {
+  const bytes = randomBytes(RAW_BYTES);
+  const token = TOKEN_PREFIX + encodeBytes(bytes);
+  const hash = hashToken(token);
+  const prefix = token.slice(0, TOKEN_PREFIX.length + 6); // e.g. "sdmcp_aB3xYz"
+  return { token, hash, prefix };
+}
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Extract a bearer token from an Authorization header.
+ * Accepts "Bearer <token>" or plain "<token>" (some MCP clients omit the scheme).
+ */
+export function extractBearer(authHeader: string | null | undefined): string | null {
+  if (!authHeader) return null;
+  const trimmed = authHeader.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^Bearer\s+(.+)$/i);
+  const raw = match ? match[1] : trimmed;
+  if (!raw.startsWith(TOKEN_PREFIX)) return null;
+  return raw;
+}

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -1,0 +1,380 @@
+/**
+ * Hosted MCP tool registration.
+ *
+ * Registers ~20 read-only detection/coverage tools on a given MCP server
+ * instance. Call registerHostedTools(server) from the route handler.
+ *
+ * Tool input schemas are defined with Zod because mcp-handler passes them
+ * through the MCP SDK's `server.tool()` API, which expects Zod shapes.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  searchDetections,
+  getDetectionById,
+  getRawYaml,
+  listDetections,
+  getStats,
+  getCoverageSummary,
+  getThreatProfileGaps,
+  getTechniqueIntelligence,
+  getTechniqueFull,
+  compareSourcesForTechnique,
+  listBySource,
+  listBySeverity,
+  listByDetectionType,
+  listByMitre,
+  listByMitreTactic,
+  searchByFilter,
+  listByAnalyticStory,
+  getActorProfile,
+  getActorIntelligence,
+  compareActors,
+  listActors,
+  generateNavigatorLayer,
+} from './db';
+
+const SOURCE_ENUM = z.enum(['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql']);
+const SEVERITY_ENUM = z.enum(['informational', 'low', 'medium', 'high', 'critical']);
+const TACTIC_ENUM = z.enum([
+  'reconnaissance',
+  'resource-development',
+  'initial-access',
+  'execution',
+  'persistence',
+  'privilege-escalation',
+  'defense-evasion',
+  'credential-access',
+  'discovery',
+  'lateral-movement',
+  'collection',
+  'command-and-control',
+  'exfiltration',
+  'impact',
+]);
+const THREAT_PROFILE_ENUM = z.enum([
+  'ransomware',
+  'apt',
+  'initial-access',
+  'persistence',
+  'credential-access',
+  'defense-evasion',
+]);
+
+type McpTextContent = { type: 'text'; text: string };
+type McpToolResult = { content: McpTextContent[]; isError?: boolean };
+
+function json(result: unknown): McpToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+}
+
+function err(message: string, extra?: Record<string, unknown>): McpToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: true, message, ...(extra ?? {}) }) }],
+    isError: true,
+  };
+}
+
+// Wrap handler to convert thrown errors into MCP tool errors with context
+async function safe(name: string, fn: () => Promise<McpToolResult>): Promise<McpToolResult> {
+  try {
+    return await fn();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[mcp-tool:${name}] ${msg}`);
+    return err(`${name} failed: ${msg}`);
+  }
+}
+
+export function registerHostedTools(server: McpServer): void {
+  // ─── Search & retrieval ─────────────────────────────────────────────────
+
+  server.tool(
+    'search',
+    'Full-text search across all detection rules (name, description, query). Supports multi-word AND queries. Returns up to 50 detections by default.',
+    {
+      query: z.string().min(1).describe('Search query (words are AND-combined)'),
+      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50)'),
+      source_type: SOURCE_ENUM.optional().describe('Filter by detection source'),
+    },
+    async ({ query, limit, source_type }) =>
+      safe('search', async () => {
+        const results = await searchDetections(query, limit ?? 50, source_type);
+        if (results.length === 0) {
+          return json({
+            count: 0,
+            detections: [],
+            hint: 'No results. Try broader keywords, remove filters, or use list_by_mitre with a technique ID.',
+          });
+        }
+        return json({ count: results.length, detections: results });
+      }),
+  );
+
+  server.tool(
+    'get_by_id',
+    'Get full details for a single detection by its ID (Sigma UUID or Splunk/Elastic slug).',
+    {
+      id: z.string().min(1).describe('Detection ID'),
+    },
+    async ({ id }) =>
+      safe('get_by_id', async () => {
+        const detection = await getDetectionById(id);
+        if (!detection) return err(`Detection not found: ${id}`, { hint: 'Use search() first to find valid IDs.' });
+        return json(detection);
+      }),
+  );
+
+  server.tool(
+    'get_raw_yaml',
+    'Get the original YAML content for a detection (useful for copying the rule verbatim).',
+    {
+      id: z.string().min(1).describe('Detection ID'),
+    },
+    async ({ id }) =>
+      safe('get_raw_yaml', async () => {
+        const yaml = await getRawYaml(id);
+        if (!yaml) return err(`No raw YAML found for: ${id}`);
+        return json({ id, yaml });
+      }),
+  );
+
+  server.tool(
+    'list_all',
+    'List detections with pagination. Prefer search() or list_by_* filters for targeted queries.',
+    {
+      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50, hard cap 100)'),
+      offset: z.number().int().min(0).optional().describe('Offset for pagination'),
+      source_type: SOURCE_ENUM.optional(),
+    },
+    async ({ limit, offset, source_type }) =>
+      safe('list_all', async () => {
+        const results = await listDetections(limit ?? 50, offset ?? 0, source_type);
+        return json({ count: results.length, offset: offset ?? 0, limit: limit ?? 50, detections: results });
+      }),
+  );
+
+  // ─── Stats & coverage ──────────────────────────────────────────────────
+
+  server.tool(
+    'get_stats',
+    'Get summary statistics about the indexed detection corpus (total detections, per-source counts, last sync).',
+    {},
+    async () => safe('get_stats', async () => json(await getStats())),
+  );
+
+  server.tool(
+    'get_coverage_summary',
+    'Get overall MITRE ATT&CK coverage summary — total techniques, covered techniques, coverage %, breakdowns by source and tactic, weakest/strongest tactics.',
+    {},
+    async () => safe('get_coverage_summary', async () => json(await getCoverageSummary())),
+  );
+
+  server.tool(
+    'analyze_coverage',
+    'Alias for get_coverage_summary — returns the same comprehensive coverage report.',
+    {},
+    async () => safe('analyze_coverage', async () => json(await getCoverageSummary())),
+  );
+
+  server.tool(
+    'identify_gaps',
+    'Identify detection gaps for a specific threat profile (ransomware, apt, initial-access, persistence, credential-access, defense-evasion). Returns prioritized uncovered techniques.',
+    {
+      threat_profile: THREAT_PROFILE_ENUM.describe('Threat profile to analyze'),
+    },
+    async ({ threat_profile }) =>
+      safe('identify_gaps', async () => json(await getThreatProfileGaps(threat_profile))),
+  );
+
+  server.tool(
+    'get_technique_intelligence',
+    'Deep intelligence for a single MITRE technique ID: detections by source, actors using it, related sub-techniques, coverage gaps.',
+    {
+      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID like T1059 or T1059.001'),
+    },
+    async ({ technique_id }) =>
+      safe('get_technique_intelligence', async () => json(await getTechniqueIntelligence(technique_id))),
+  );
+
+  server.tool(
+    'get_technique_full',
+    'Full technique detail: all covering detections (paginated), actors using it, procedures, per-source breakdown.',
+    {
+      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
+      detection_limit: z.number().int().min(1).max(100).optional().describe('Max detections to return (default 50)'),
+    },
+    async ({ technique_id, detection_limit }) =>
+      safe('get_technique_full', async () => json(await getTechniqueFull(technique_id, detection_limit ?? 50))),
+  );
+
+  server.tool(
+    'compare_sources',
+    'Cross-source comparison for a MITRE technique: how many detections does each source (Sigma, Splunk, Elastic, KQL, Sublime, CQL) have for this technique, and which sources have no coverage.',
+    {
+      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
+    },
+    async ({ technique_id }) =>
+      safe('compare_sources', async () => json(await compareSourcesForTechnique(technique_id))),
+  );
+
+  server.tool(
+    'generate_navigator_layer',
+    'Generate a MITRE ATT&CK Navigator JSON layer showing covered techniques. Output can be pasted directly into the Navigator web app.',
+    {
+      name: z.string().optional().describe('Layer name shown in Navigator'),
+      source_type: SOURCE_ENUM.optional().describe('Limit the layer to one source'),
+    },
+    async ({ name, source_type }) =>
+      safe('generate_navigator_layer', async () => json(await generateNavigatorLayer({ name, sourceType: source_type }))),
+  );
+
+  // ─── Filters ───────────────────────────────────────────────────────────
+
+  server.tool(
+    'list_by_source',
+    'List detections from a specific source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql).',
+    {
+      source_type: SOURCE_ENUM,
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ source_type, limit }) =>
+      safe('list_by_source', async () => json({ count: 0, source_type, detections: await listBySource(source_type, limit ?? 50) })),
+  );
+
+  server.tool(
+    'list_by_severity',
+    'List detections at a specific severity (informational, low, medium, high, critical).',
+    {
+      severity: SEVERITY_ENUM,
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ severity, limit }) =>
+      safe('list_by_severity', async () => json({ severity, detections: await listBySeverity(severity, limit ?? 50) })),
+  );
+
+  server.tool(
+    'list_by_detection_type',
+    'List detections by detection type (e.g., "TTP", "Anomaly", "Hunting", "Correlation").',
+    {
+      detection_type: z.string().min(1).describe('Detection type label'),
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ detection_type, limit }) =>
+      safe('list_by_detection_type', async () =>
+        json({ detection_type, detections: await listByDetectionType(detection_type, limit ?? 50) }),
+      ),
+  );
+
+  server.tool(
+    'list_by_mitre',
+    'List detections that reference a specific MITRE technique ID (via the detection_techniques junction table).',
+    {
+      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID like T1059.001'),
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ technique_id, limit }) =>
+      safe('list_by_mitre', async () => json({ technique_id, detections: await listByMitre(technique_id, limit ?? 50) })),
+  );
+
+  server.tool(
+    'list_by_mitre_tactic',
+    'List detections that map to a specific MITRE tactic (e.g., credential-access, defense-evasion).',
+    {
+      tactic: TACTIC_ENUM,
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ tactic, limit }) =>
+      safe('list_by_mitre_tactic', async () => json({ tactic, detections: await listByMitreTactic(tactic, limit ?? 50) })),
+  );
+
+  server.tool(
+    'list_by_cve',
+    'Find detections that reference a specific CVE ID.',
+    {
+      cve: z.string().regex(/^CVE-\d{4}-\d{4,7}$/).describe('CVE identifier like CVE-2024-12345'),
+      limit: z.number().int().min(1).max(50).optional(),
+    },
+    async ({ cve, limit }) =>
+      safe('list_by_cve', async () => json(await searchByFilter('cve', cve, limit ?? 20))),
+  );
+
+  server.tool(
+    'list_by_process_name',
+    'Find detections that monitor a specific process name (e.g., rundll32.exe, powershell.exe).',
+    {
+      process_name: z.string().min(1).describe('Process executable name'),
+      limit: z.number().int().min(1).max(50).optional(),
+    },
+    async ({ process_name, limit }) =>
+      safe('list_by_process_name', async () => json(await searchByFilter('process_name', process_name, limit ?? 20))),
+  );
+
+  server.tool(
+    'list_by_data_source',
+    'Find detections that require a specific data source (e.g., "Sysmon", "Windows Event Log", "Process Creation").',
+    {
+      data_source: z.string().min(1).describe('Data source name'),
+      limit: z.number().int().min(1).max(50).optional(),
+    },
+    async ({ data_source, limit }) =>
+      safe('list_by_data_source', async () => json(await searchByFilter('data_source', data_source, limit ?? 20))),
+  );
+
+  server.tool(
+    'list_by_analytic_story',
+    'List detections that belong to a Splunk Analytic Story (e.g., "Ransomware", "Cloud Federated Credential Abuse").',
+    {
+      story: z.string().min(1).describe('Analytic story name'),
+      limit: z.number().int().min(1).max(100).optional(),
+    },
+    async ({ story, limit }) =>
+      safe('list_by_analytic_story', async () =>
+        json({ story, detections: await listByAnalyticStory(story, limit ?? 50) }),
+      ),
+  );
+
+  // ─── Threat actors ─────────────────────────────────────────────────────
+
+  server.tool(
+    'list_actors',
+    'List or search MITRE ATT&CK threat actors. Pass a query to search by name or alias.',
+    {
+      query: z.string().optional().describe('Search term (matches name and aliases)'),
+      limit: z.number().int().min(1).max(200).optional(),
+    },
+    async ({ query, limit }) =>
+      safe('list_actors', async () => json({ actors: await listActors(limit ?? 50, query) })),
+  );
+
+  server.tool(
+    'get_actor_profile',
+    'Get a full profile for a threat actor: description, aliases, technique list, and detection coverage %.',
+    {
+      actor_name: z.string().min(1).describe('Threat actor name (e.g., "APT29", "FIN7")'),
+    },
+    async ({ actor_name }) =>
+      safe('get_actor_profile', async () => json(await getActorProfile(actor_name))),
+  );
+
+  server.tool(
+    'analyze_actor_coverage',
+    'Deep intelligence about a threat actor: per-tactic coverage breakdown, covered techniques with detection counts, and all uncovered technique gaps.',
+    {
+      actor_name: z.string().min(1).describe('Threat actor name'),
+    },
+    async ({ actor_name }) =>
+      safe('analyze_actor_coverage', async () => json(await getActorIntelligence(actor_name))),
+  );
+
+  server.tool(
+    'compare_actor_coverage',
+    'Compare two or more threat actors side-by-side: total techniques, coverage %, shared gaps, unique gaps.',
+    {
+      actor_names: z.array(z.string().min(1)).min(2).max(5).describe('Between 2 and 5 actor names to compare'),
+    },
+    async ({ actor_names }) =>
+      safe('compare_actor_coverage', async () => json(await compareActors(actor_names))),
+  );
+}

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -1,11 +1,19 @@
 /**
  * Hosted MCP tool registration.
  *
- * Registers ~20 read-only detection/coverage tools on a given MCP server
+ * Registers ~25 read-only detection/coverage tools on a given MCP server
  * instance. Call registerHostedTools(server) from the route handler.
  *
- * Tool input schemas are defined with Zod because mcp-handler passes them
- * through the MCP SDK's `server.tool()` API, which expects Zod shapes.
+ * Uses the modern SDK `registerTool()` API (not the deprecated `tool()`)
+ * so we can set:
+ *   - title       — human-readable display name
+ *   - annotations — readOnlyHint, destructiveHint, idempotentHint, openWorldHint
+ *   - _meta       — platform metadata for clients that surface it
+ *
+ * All tools in this module are READ-ONLY, IDEMPOTENT, and operate on a
+ * CLOSED-WORLD corpus (our indexed detection set), so the annotations
+ * below apply uniformly and Claude Code / Cursor will not prompt the
+ * user on repeated calls.
  */
 
 import { z } from 'zod';
@@ -35,6 +43,8 @@ import {
   generateNavigatorLayer,
 } from './db';
 
+// ─── Schemas shared across tools ──────────────────────────────────────────
+
 const SOURCE_ENUM = z.enum(['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql']);
 const SEVERITY_ENUM = z.enum(['informational', 'low', 'medium', 'high', 'critical']);
 const TACTIC_ENUM = z.enum([
@@ -62,6 +72,21 @@ const THREAT_PROFILE_ENUM = z.enum([
   'defense-evasion',
 ]);
 
+// ─── Shared annotations + helpers ─────────────────────────────────────────
+
+// All hosted tools are read-only queries against our detection corpus.
+const READ_ONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+const META = {
+  'detect.michaelhaag.org/category': 'security-detections',
+  'detect.michaelhaag.org/version': '1.0.0',
+} as const;
+
 type McpTextContent = { type: 'text'; text: string };
 type McpToolResult = { content: McpTextContent[]; isError?: boolean };
 
@@ -76,7 +101,6 @@ function err(message: string, extra?: Record<string, unknown>): McpToolResult {
   };
 }
 
-// Wrap handler to convert thrown errors into MCP tool errors with context
 async function safe(name: string, fn: () => Promise<McpToolResult>): Promise<McpToolResult> {
   try {
     return await fn();
@@ -87,16 +111,24 @@ async function safe(name: string, fn: () => Promise<McpToolResult>): Promise<Mcp
   }
 }
 
-export function registerHostedTools(server: McpServer): void {
-  // ─── Search & retrieval ─────────────────────────────────────────────────
+// ─── Tool registration ────────────────────────────────────────────────────
 
-  server.tool(
+export function registerHostedTools(server: McpServer): void {
+  // ─── Search & retrieval ────────────────────────────────────────────────
+
+  server.registerTool(
     'search',
-    'Full-text search across all detection rules (name, description, query). Supports multi-word AND queries. Returns up to 50 detections by default.',
     {
-      query: z.string().min(1).describe('Search query (words are AND-combined)'),
-      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50)'),
-      source_type: SOURCE_ENUM.optional().describe('Filter by detection source'),
+      title: 'Search Detections',
+      description:
+        'Full-text search across all detection rules (name, description, query). Supports multi-word AND queries. Returns up to 50 detections by default.',
+      inputSchema: {
+        query: z.string().min(1).describe('Search query (words are AND-combined)'),
+        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50)'),
+        source_type: SOURCE_ENUM.optional().describe('Filter by detection source'),
+      },
+      annotations: { title: 'Search Detections', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ query, limit, source_type }) =>
       safe('search', async () => {
@@ -112,11 +144,16 @@ export function registerHostedTools(server: McpServer): void {
       }),
   );
 
-  server.tool(
+  server.registerTool(
     'get_by_id',
-    'Get full details for a single detection by its ID (Sigma UUID or Splunk/Elastic slug).',
     {
-      id: z.string().min(1).describe('Detection ID'),
+      title: 'Get Detection by ID',
+      description: 'Get full details for a single detection by its ID (Sigma UUID or Splunk/Elastic slug).',
+      inputSchema: {
+        id: z.string().min(1).describe('Detection ID'),
+      },
+      annotations: { title: 'Get Detection by ID', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ id }) =>
       safe('get_by_id', async () => {
@@ -126,11 +163,16 @@ export function registerHostedTools(server: McpServer): void {
       }),
   );
 
-  server.tool(
+  server.registerTool(
     'get_raw_yaml',
-    'Get the original YAML content for a detection (useful for copying the rule verbatim).',
     {
-      id: z.string().min(1).describe('Detection ID'),
+      title: 'Get Raw YAML',
+      description: 'Get the original YAML content for a detection (useful for copying the rule verbatim).',
+      inputSchema: {
+        id: z.string().min(1).describe('Detection ID'),
+      },
+      annotations: { title: 'Get Raw YAML', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ id }) =>
       safe('get_raw_yaml', async () => {
@@ -140,13 +182,18 @@ export function registerHostedTools(server: McpServer): void {
       }),
   );
 
-  server.tool(
+  server.registerTool(
     'list_all',
-    'List detections with pagination. Prefer search() or list_by_* filters for targeted queries.',
     {
-      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50, hard cap 100)'),
-      offset: z.number().int().min(0).optional().describe('Offset for pagination'),
-      source_type: SOURCE_ENUM.optional(),
+      title: 'List Detections',
+      description: 'List detections with pagination. Prefer search() or list_by_* filters for targeted queries.',
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 50, hard cap 100)'),
+        offset: z.number().int().min(0).optional().describe('Offset for pagination'),
+        source_type: SOURCE_ENUM.optional(),
+      },
+      annotations: { title: 'List Detections', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ limit, offset, source_type }) =>
       safe('list_all', async () => {
@@ -155,111 +202,181 @@ export function registerHostedTools(server: McpServer): void {
       }),
   );
 
-  // ─── Stats & coverage ──────────────────────────────────────────────────
+  // ─── Stats & coverage ─────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'get_stats',
-    'Get summary statistics about the indexed detection corpus (total detections, per-source counts, last sync).',
-    {},
+    {
+      title: 'Get Detection Stats',
+      description: 'Get summary statistics about the indexed detection corpus (total detections, per-source counts, last sync).',
+      inputSchema: {},
+      annotations: { title: 'Get Detection Stats', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
+    },
     async () => safe('get_stats', async () => json(await getStats())),
   );
 
-  server.tool(
+  server.registerTool(
     'get_coverage_summary',
-    'Get overall MITRE ATT&CK coverage summary — total techniques, covered techniques, coverage %, breakdowns by source and tactic, weakest/strongest tactics.',
-    {},
+    {
+      title: 'Coverage Summary',
+      description:
+        'Get overall MITRE ATT&CK coverage summary — total techniques, covered techniques, coverage %, breakdowns by source and tactic, weakest/strongest tactics.',
+      inputSchema: {},
+      annotations: { title: 'Coverage Summary', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
+    },
     async () => safe('get_coverage_summary', async () => json(await getCoverageSummary())),
   );
 
-  server.tool(
+  server.registerTool(
     'analyze_coverage',
-    'Alias for get_coverage_summary — returns the same comprehensive coverage report.',
-    {},
+    {
+      title: 'Analyze Coverage',
+      description: 'Alias for get_coverage_summary — returns the same comprehensive coverage report.',
+      inputSchema: {},
+      annotations: { title: 'Analyze Coverage', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
+    },
     async () => safe('analyze_coverage', async () => json(await getCoverageSummary())),
   );
 
-  server.tool(
+  server.registerTool(
     'identify_gaps',
-    'Identify detection gaps for a specific threat profile (ransomware, apt, initial-access, persistence, credential-access, defense-evasion). Returns prioritized uncovered techniques.',
     {
-      threat_profile: THREAT_PROFILE_ENUM.describe('Threat profile to analyze'),
+      title: 'Identify Detection Gaps',
+      description:
+        'Identify detection gaps for a specific threat profile (ransomware, apt, initial-access, persistence, credential-access, defense-evasion). Returns prioritized uncovered techniques.',
+      inputSchema: {
+        threat_profile: THREAT_PROFILE_ENUM.describe('Threat profile to analyze'),
+      },
+      annotations: { title: 'Identify Detection Gaps', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ threat_profile }) =>
       safe('identify_gaps', async () => json(await getThreatProfileGaps(threat_profile))),
   );
 
-  server.tool(
+  server.registerTool(
     'get_technique_intelligence',
-    'Deep intelligence for a single MITRE technique ID: detections by source, actors using it, related sub-techniques, coverage gaps.',
     {
-      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID like T1059 or T1059.001'),
+      title: 'Technique Intelligence',
+      description:
+        'Deep intelligence for a single MITRE technique ID: detections by source, actors using it, related sub-techniques, coverage gaps.',
+      inputSchema: {
+        technique_id: z
+          .string()
+          .regex(/^T\d{4}(\.\d{3})?$/)
+          .describe('MITRE technique ID like T1059 or T1059.001'),
+      },
+      annotations: { title: 'Technique Intelligence', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ technique_id }) =>
       safe('get_technique_intelligence', async () => json(await getTechniqueIntelligence(technique_id))),
   );
 
-  server.tool(
+  server.registerTool(
     'get_technique_full',
-    'Full technique detail: all covering detections (paginated), actors using it, procedures, per-source breakdown.',
     {
-      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
-      detection_limit: z.number().int().min(1).max(100).optional().describe('Max detections to return (default 50)'),
+      title: 'Full Technique Detail',
+      description:
+        'Full technique detail: all covering detections (paginated), actors using it, procedures, per-source breakdown.',
+      inputSchema: {
+        technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
+        detection_limit: z.number().int().min(1).max(100).optional().describe('Max detections to return (default 50)'),
+      },
+      annotations: { title: 'Full Technique Detail', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ technique_id, detection_limit }) =>
       safe('get_technique_full', async () => json(await getTechniqueFull(technique_id, detection_limit ?? 50))),
   );
 
-  server.tool(
+  server.registerTool(
     'compare_sources',
-    'Cross-source comparison for a MITRE technique: how many detections does each source (Sigma, Splunk, Elastic, KQL, Sublime, CQL) have for this technique, and which sources have no coverage.',
     {
-      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
+      title: 'Cross-Source Comparison',
+      description:
+        'Cross-source comparison for a MITRE technique: how many detections does each source (Sigma, Splunk, Elastic, KQL, Sublime, CQL) have for this technique, and which sources have no coverage.',
+      inputSchema: {
+        technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID'),
+      },
+      annotations: { title: 'Cross-Source Comparison', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ technique_id }) =>
       safe('compare_sources', async () => json(await compareSourcesForTechnique(technique_id))),
   );
 
-  server.tool(
+  server.registerTool(
     'generate_navigator_layer',
-    'Generate a MITRE ATT&CK Navigator JSON layer showing covered techniques. Output can be pasted directly into the Navigator web app.',
     {
-      name: z.string().optional().describe('Layer name shown in Navigator'),
-      source_type: SOURCE_ENUM.optional().describe('Limit the layer to one source'),
+      title: 'Generate Navigator Layer',
+      description:
+        'Generate a MITRE ATT&CK Navigator JSON layer showing covered techniques. Output can be pasted directly into the Navigator web app.',
+      inputSchema: {
+        name: z.string().optional().describe('Layer name shown in Navigator'),
+        source_type: SOURCE_ENUM.optional().describe('Limit the layer to one source'),
+      },
+      annotations: { title: 'Generate Navigator Layer', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ name, source_type }) =>
-      safe('generate_navigator_layer', async () => json(await generateNavigatorLayer({ name, sourceType: source_type }))),
+      safe('generate_navigator_layer', async () =>
+        json(await generateNavigatorLayer({ name, sourceType: source_type })),
+      ),
   );
 
-  // ─── Filters ───────────────────────────────────────────────────────────
+  // ─── Filters ──────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'list_by_source',
-    'List detections from a specific source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql).',
     {
-      source_type: SOURCE_ENUM,
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by Source',
+      description: 'List detections from a specific source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql).',
+      inputSchema: {
+        source_type: SOURCE_ENUM,
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by Source', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ source_type, limit }) =>
-      safe('list_by_source', async () => json({ count: 0, source_type, detections: await listBySource(source_type, limit ?? 50) })),
+      safe('list_by_source', async () =>
+        json({ source_type, detections: await listBySource(source_type, limit ?? 50) }),
+      ),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_severity',
-    'List detections at a specific severity (informational, low, medium, high, critical).',
     {
-      severity: SEVERITY_ENUM,
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by Severity',
+      description: 'List detections at a specific severity (informational, low, medium, high, critical).',
+      inputSchema: {
+        severity: SEVERITY_ENUM,
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by Severity', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ severity, limit }) =>
-      safe('list_by_severity', async () => json({ severity, detections: await listBySeverity(severity, limit ?? 50) })),
+      safe('list_by_severity', async () =>
+        json({ severity, detections: await listBySeverity(severity, limit ?? 50) }),
+      ),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_detection_type',
-    'List detections by detection type (e.g., "TTP", "Anomaly", "Hunting", "Correlation").',
     {
-      detection_type: z.string().min(1).describe('Detection type label'),
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by Detection Type',
+      description: 'List detections by detection type (e.g., "TTP", "Anomaly", "Hunting", "Correlation").',
+      inputSchema: {
+        detection_type: z.string().min(1).describe('Detection type label'),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by Detection Type', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ detection_type, limit }) =>
       safe('list_by_detection_type', async () =>
@@ -267,67 +384,101 @@ export function registerHostedTools(server: McpServer): void {
       ),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_mitre',
-    'List detections that reference a specific MITRE technique ID (via the detection_techniques junction table).',
     {
-      technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID like T1059.001'),
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by MITRE Technique',
+      description: 'List detections that reference a specific MITRE technique ID (via the detection_techniques junction table).',
+      inputSchema: {
+        technique_id: z.string().regex(/^T\d{4}(\.\d{3})?$/).describe('MITRE technique ID like T1059.001'),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by MITRE Technique', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ technique_id, limit }) =>
-      safe('list_by_mitre', async () => json({ technique_id, detections: await listByMitre(technique_id, limit ?? 50) })),
+      safe('list_by_mitre', async () =>
+        json({ technique_id, detections: await listByMitre(technique_id, limit ?? 50) }),
+      ),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_mitre_tactic',
-    'List detections that map to a specific MITRE tactic (e.g., credential-access, defense-evasion).',
     {
-      tactic: TACTIC_ENUM,
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by MITRE Tactic',
+      description: 'List detections that map to a specific MITRE tactic (e.g., credential-access, defense-evasion).',
+      inputSchema: {
+        tactic: TACTIC_ENUM,
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by MITRE Tactic', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ tactic, limit }) =>
-      safe('list_by_mitre_tactic', async () => json({ tactic, detections: await listByMitreTactic(tactic, limit ?? 50) })),
+      safe('list_by_mitre_tactic', async () =>
+        json({ tactic, detections: await listByMitreTactic(tactic, limit ?? 50) }),
+      ),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_cve',
-    'Find detections that reference a specific CVE ID.',
     {
-      cve: z.string().regex(/^CVE-\d{4}-\d{4,7}$/).describe('CVE identifier like CVE-2024-12345'),
-      limit: z.number().int().min(1).max(50).optional(),
+      title: 'List by CVE',
+      description: 'Find detections that reference a specific CVE ID.',
+      inputSchema: {
+        cve: z.string().regex(/^CVE-\d{4}-\d{4,7}$/).describe('CVE identifier like CVE-2024-12345'),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+      annotations: { title: 'List by CVE', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ cve, limit }) =>
       safe('list_by_cve', async () => json(await searchByFilter('cve', cve, limit ?? 20))),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_process_name',
-    'Find detections that monitor a specific process name (e.g., rundll32.exe, powershell.exe).',
     {
-      process_name: z.string().min(1).describe('Process executable name'),
-      limit: z.number().int().min(1).max(50).optional(),
+      title: 'List by Process Name',
+      description: 'Find detections that monitor a specific process name (e.g., rundll32.exe, powershell.exe).',
+      inputSchema: {
+        process_name: z.string().min(1).describe('Process executable name'),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+      annotations: { title: 'List by Process Name', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ process_name, limit }) =>
       safe('list_by_process_name', async () => json(await searchByFilter('process_name', process_name, limit ?? 20))),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_data_source',
-    'Find detections that require a specific data source (e.g., "Sysmon", "Windows Event Log", "Process Creation").',
     {
-      data_source: z.string().min(1).describe('Data source name'),
-      limit: z.number().int().min(1).max(50).optional(),
+      title: 'List by Data Source',
+      description: 'Find detections that require a specific data source (e.g., "Sysmon", "Windows Event Log", "Process Creation").',
+      inputSchema: {
+        data_source: z.string().min(1).describe('Data source name'),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+      annotations: { title: 'List by Data Source', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ data_source, limit }) =>
       safe('list_by_data_source', async () => json(await searchByFilter('data_source', data_source, limit ?? 20))),
   );
 
-  server.tool(
+  server.registerTool(
     'list_by_analytic_story',
-    'List detections that belong to a Splunk Analytic Story (e.g., "Ransomware", "Cloud Federated Credential Abuse").',
     {
-      story: z.string().min(1).describe('Analytic story name'),
-      limit: z.number().int().min(1).max(100).optional(),
+      title: 'List by Analytic Story',
+      description: 'List detections that belong to a Splunk Analytic Story (e.g., "Ransomware", "Cloud Federated Credential Abuse").',
+      inputSchema: {
+        story: z.string().min(1).describe('Analytic story name'),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      annotations: { title: 'List by Analytic Story', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ story, limit }) =>
       safe('list_by_analytic_story', async () =>
@@ -335,44 +486,66 @@ export function registerHostedTools(server: McpServer): void {
       ),
   );
 
-  // ─── Threat actors ─────────────────────────────────────────────────────
+  // ─── Threat actors ────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'list_actors',
-    'List or search MITRE ATT&CK threat actors. Pass a query to search by name or alias.',
     {
-      query: z.string().optional().describe('Search term (matches name and aliases)'),
-      limit: z.number().int().min(1).max(200).optional(),
+      title: 'List Threat Actors',
+      description: 'List or search MITRE ATT&CK threat actors. Pass a query to search by name or alias.',
+      inputSchema: {
+        query: z.string().optional().describe('Search term (matches name and aliases)'),
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+      annotations: { title: 'List Threat Actors', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ query, limit }) =>
       safe('list_actors', async () => json({ actors: await listActors(limit ?? 50, query) })),
   );
 
-  server.tool(
+  server.registerTool(
     'get_actor_profile',
-    'Get a full profile for a threat actor: description, aliases, technique list, and detection coverage %.',
     {
-      actor_name: z.string().min(1).describe('Threat actor name (e.g., "APT29", "FIN7")'),
+      title: 'Threat Actor Profile',
+      description: 'Get a full profile for a threat actor: description, aliases, technique list, and detection coverage %.',
+      inputSchema: {
+        actor_name: z.string().min(1).describe('Threat actor name (e.g., "APT29", "FIN7")'),
+      },
+      annotations: { title: 'Threat Actor Profile', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ actor_name }) =>
       safe('get_actor_profile', async () => json(await getActorProfile(actor_name))),
   );
 
-  server.tool(
+  server.registerTool(
     'analyze_actor_coverage',
-    'Deep intelligence about a threat actor: per-tactic coverage breakdown, covered techniques with detection counts, and all uncovered technique gaps.',
     {
-      actor_name: z.string().min(1).describe('Threat actor name'),
+      title: 'Analyze Actor Coverage',
+      description:
+        'Deep intelligence about a threat actor: per-tactic coverage breakdown, covered techniques with detection counts, and all uncovered technique gaps.',
+      inputSchema: {
+        actor_name: z.string().min(1).describe('Threat actor name'),
+      },
+      annotations: { title: 'Analyze Actor Coverage', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ actor_name }) =>
       safe('analyze_actor_coverage', async () => json(await getActorIntelligence(actor_name))),
   );
 
-  server.tool(
+  server.registerTool(
     'compare_actor_coverage',
-    'Compare two or more threat actors side-by-side: total techniques, coverage %, shared gaps, unique gaps.',
     {
-      actor_names: z.array(z.string().min(1)).min(2).max(5).describe('Between 2 and 5 actor names to compare'),
+      title: 'Compare Actor Coverage',
+      description:
+        'Compare two or more threat actors side-by-side: total techniques, coverage %, shared gaps, unique gaps.',
+      inputSchema: {
+        actor_names: z.array(z.string().min(1)).min(2).max(5).describe('Between 2 and 5 actor names to compare'),
+      },
+      annotations: { title: 'Compare Actor Coverage', ...READ_ONLY_ANNOTATIONS },
+      _meta: META,
     },
     async ({ actor_names }) =>
       safe('compare_actor_coverage', async () => json(await compareActors(actor_names))),

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -13,8 +13,9 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - public files (images, etc.)
+     * - api/mcp (hosted MCP endpoint — uses bearer token auth, not cookies)
      * - api routes that don't need auth (search, coverage are public)
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api/mcp|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -15,6 +15,23 @@ const nextConfig: NextConfig = {
     ],
   },
   // Turbopack is default in dev via --turbopack flag
+
+  // RFC 9728 Protected Resource Metadata — MCP clients fetch this URL
+  // after a 401 to discover auth. Next.js disallows `.well-known` in the
+  // app/ directory because of the leading dot, so we rewrite to an
+  // api/ route handler.
+  async rewrites() {
+    return [
+      {
+        source: '/.well-known/oauth-protected-resource',
+        destination: '/api/well-known/oauth-protected-resource',
+      },
+      {
+        source: '/.well-known/oauth-protected-resource/:path*',
+        destination: '/api/well-known/oauth-protected-resource',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,11 +8,14 @@
       "name": "security-detections-web",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.3",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.4",
+        "mcp-handler": "^1.0.1",
         "next": "^15.3.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -219,6 +222,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -789,6 +804,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -992,6 +1069,65 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -2027,6 +2163,19 @@
         "win32"
       ]
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2066,6 +2215,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -2378,6 +2566,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -2427,6 +2639,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -2450,7 +2671,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2464,7 +2684,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2537,6 +2756,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2557,12 +2785,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2577,11 +2836,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2664,7 +2948,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2747,6 +3030,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2787,7 +3079,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2798,12 +3089,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2902,7 +3208,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2912,7 +3217,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2950,7 +3254,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3005,6 +3308,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3426,6 +3735,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3436,11 +3775,80 @@
         "node": ">=6"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3487,6 +3895,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3528,6 +3952,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3584,6 +4029,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3595,7 +4058,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3642,11 +4104,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3671,7 +4141,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3766,7 +4235,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3838,7 +4306,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3867,13 +4334,41 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iceberg-js": {
@@ -3883,6 +4378,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3947,7 +4458,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -3970,6 +4480,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4229,6 +4757,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4385,7 +4919,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4414,6 +4947,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -4449,6 +4991,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4841,10 +5389,70 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -4869,6 +5477,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-response": {
@@ -4918,7 +5551,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4968,6 +5600,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "15.5.15",
@@ -5095,7 +5736,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5105,7 +5745,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5214,11 +5853,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5305,6 +5955,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5319,7 +5978,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5331,6 +5989,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5349,6 +6017,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5440,6 +6117,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -5459,6 +6149,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5481,6 +6186,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -5551,6 +6280,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5593,6 +6339,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5648,6 +6403,22 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-parallel": {
@@ -5750,6 +6521,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5767,6 +6544,51 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -5818,6 +6640,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -5867,7 +6695,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5880,7 +6707,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5890,7 +6716,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5910,7 +6735,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5927,7 +6751,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5946,7 +6769,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6024,6 +6846,15 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6346,6 +7177,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6402,6 +7242,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6521,6 +7375,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -6573,11 +7436,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6692,7 +7563,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -6716,6 +7586,12 @@
         }
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6727,6 +7603,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -11,11 +11,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.3",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
+    "mcp-handler": "^1.0.1",
     "next": "^15.3.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/web/supabase/migrations/014_mcp_tokens.sql
+++ b/web/supabase/migrations/014_mcp_tokens.sql
@@ -1,0 +1,134 @@
+-- =============================================================================
+-- 014_mcp_tokens.sql — Hosted MCP token table + atomic rate-limit RPC
+-- Enables the hosted Streamable HTTP MCP endpoint at /api/mcp/[transport].
+-- Users generate tokens from /account/tokens; we only store sha256(token).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  prefix TEXT NOT NULL,                            -- first 12 chars of token for display (e.g. "sdmcp_ab12cd")
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  calls_today INTEGER NOT NULL DEFAULT 0,
+  calls_reset_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  total_calls BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_user ON mcp_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_hash ON mcp_tokens(token_hash) WHERE revoked_at IS NULL;
+
+-- ─── RLS: users can only see and revoke their own tokens ──────────────────────
+-- Note: the MCP route handler uses the SERVICE ROLE client to look up token
+-- hashes and call increment_mcp_call(), so RLS here protects the UI only.
+
+ALTER TABLE mcp_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY mcp_tokens_select_own ON mcp_tokens
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY mcp_tokens_insert_own ON mcp_tokens
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- Updates allowed only to set revoked_at (revocation). Fine-grained column
+-- restrictions aren't in Postgres RLS, so we rely on the /api/account/tokens
+-- route handler (which uses the service client) to only set revoked_at.
+CREATE POLICY mcp_tokens_update_own ON mcp_tokens
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- ─── Atomic rate-limit RPC ────────────────────────────────────────────────────
+-- Called by the MCP route handler (service role) on every tool call.
+-- Returns JSON: { ok, token_id, user_id, remaining, tier } or { ok: false, reason }.
+-- Does everything in one round-trip: lookup by hash, check revocation, check
+-- daily quota, increment counter, update last_used_at.
+
+CREATE OR REPLACE FUNCTION increment_mcp_call(p_token_hash TEXT)
+RETURNS JSON AS $$
+DECLARE
+  v_token mcp_tokens%ROWTYPE;
+  v_tier TEXT;
+  v_limit INT;
+BEGIN
+  -- Lock the token row for atomic update
+  SELECT * INTO v_token
+  FROM mcp_tokens
+  WHERE token_hash = p_token_hash
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('ok', false, 'reason', 'invalid_token');
+  END IF;
+
+  IF v_token.revoked_at IS NOT NULL THEN
+    RETURN json_build_object('ok', false, 'reason', 'revoked');
+  END IF;
+
+  -- Resolve limit from user tier
+  SELECT tier INTO v_tier FROM profiles WHERE id = v_token.user_id;
+  v_tier := COALESCE(v_tier, 'free');
+
+  IF v_tier = 'blocked' THEN
+    RETURN json_build_object('ok', false, 'reason', 'blocked');
+  END IF;
+
+  v_limit := CASE v_tier
+    WHEN 'admin' THEN 100000
+    WHEN 'pro' THEN 5000
+    ELSE 200                                         -- free
+  END;
+
+  -- Reset daily counter if new day
+  IF v_token.calls_reset_at < CURRENT_DATE THEN
+    UPDATE mcp_tokens
+      SET calls_today = 1,
+          calls_reset_at = CURRENT_DATE,
+          last_used_at = now(),
+          total_calls = total_calls + 1
+      WHERE id = v_token.id;
+    RETURN json_build_object(
+      'ok', true,
+      'token_id', v_token.id,
+      'user_id', v_token.user_id,
+      'tier', v_tier,
+      'limit', v_limit,
+      'remaining', v_limit - 1
+    );
+  END IF;
+
+  -- Quota check
+  IF v_token.calls_today >= v_limit THEN
+    RETURN json_build_object(
+      'ok', false,
+      'reason', 'quota_exceeded',
+      'tier', v_tier,
+      'limit', v_limit,
+      'remaining', 0
+    );
+  END IF;
+
+  -- Increment
+  UPDATE mcp_tokens
+    SET calls_today = calls_today + 1,
+        last_used_at = now(),
+        total_calls = total_calls + 1
+    WHERE id = v_token.id;
+
+  RETURN json_build_object(
+    'ok', true,
+    'token_id', v_token.id,
+    'user_id', v_token.user_id,
+    'tier', v_tier,
+    'limit', v_limit,
+    'remaining', v_limit - (v_token.calls_today + 1)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Only the service role should call this; deny public/anon execution.
+REVOKE ALL ON FUNCTION increment_mcp_call(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION increment_mcp_call(TEXT) FROM anon;
+REVOKE ALL ON FUNCTION increment_mcp_call(TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION increment_mcp_call(TEXT) TO service_role;


### PR DESCRIPTION
## Summary

Adds a **hosted Streamable HTTP MCP server** at `https://detect.michaelhaag.org/api/mcp/http` so users can point Claude Desktop / Cursor / Claude Code at one URL and query the Supabase-backed detection corpus without installing the stdio npm package.

Flow: sign in → visit `/account/tokens` → generate `sdmcp_...` token → paste it into an MCP client as a `Bearer` header → start asking questions.

This is **additive only** — nothing in `src/` (the stdio npm package) changes.

## Architecture

```
MCP client  ── HTTPS ──►  /api/mcp/http  (Next.js route handler, mcp-handler, stateless)
                                │
                                ▼
                       Bearer-token auth + atomic rate limit (increment_mcp_call RPC)
                                │
                                ▼
                       ~25 read-only tools registered via lib/mcp/tools.ts
                                │
                                ▼
                       lib/mcp/db.ts  ──►  Supabase service-role client
                                            (search_detections_full, get_actor_intelligence,
                                             get_threat_profile_gaps, compare_sources_for_technique,
                                             get_coverage_summary, etc. — existing RPCs)
```

**Transport:** Streamable HTTP only, stateless. No Redis, no session store — fits Vercel serverless natively. `runtime = 'nodejs'`, `maxDuration = 60`.

**Design choices** (confirmed before implementation):
1. **Read-only tool subset** — ~25 tools: search, retrieval, filters, coverage analysis, gap analysis, actor profiling, Navigator layer export. Excludes stateful tools (knowledge graph, dynamic tables, templates, autonomous analysis).
2. **Token required, tied to account** — enables revocation, per-tier quotas, usage metering.
3. **Streamable HTTP stateless** — modern MCP spec, supported by every current client, serverless-native.

## What's in the box

### Database (`supabase/migrations/014_mcp_tokens.sql`)
- `mcp_tokens` table: id, user_id (FK `auth.users`), `token_hash` (unique, SHA-256), `name`, `prefix` (first 12 chars for display), `created_at`, `last_used_at`, `revoked_at`, `calls_today`, `calls_reset_at`, `total_calls`.
- RLS: users can select/insert/update only their own tokens.
- `increment_mcp_call(p_token_hash text) RETURNS json` — `SECURITY DEFINER` with row lock. One round-trip: lookup, revocation check, tier → quota resolution, daily reset, increment, `last_used_at` update. Granted to `service_role` only; revoked from `anon` / `authenticated` / `public`.
- **Tier quotas:** free 200/day, pro 5 000/day, admin 100 000/day. Reuses the existing `profiles.tier` column.

### MCP server (`web/lib/mcp/`, `web/app/api/mcp/[transport]/route.ts`)
- **`lib/mcp/tokens.ts`** — generates `sdmcp_<base62>` tokens (32 random bytes), stores only SHA-256 hash. `extractBearer()` accepts `Bearer <token>`, plain `<token>`, or `x-mcp-token`.
- **`lib/mcp/auth.ts`** — wraps every request: extracts bearer, hashes, calls `increment_mcp_call`, returns either a fully-formed JSON-RPC error `Response` or an `AuthContext`. Maps RPC failure reasons to JSON-RPC codes (-32001 invalid, -32002 blocked, -32003 quota_exceeded).
- **`lib/mcp/db.ts`** — Supabase service-role query layer. Most functions are thin wrappers over the existing RPCs in `002_rls_and_functions.sql` (`search_detections_full`, `get_technique_intelligence`, `get_actor_intelligence`, `get_threat_profile_gaps`, `compare_sources_for_technique`, `get_actor_profile_full`, `compare_actors`, `search_detections_by_filter`, etc.) — **no SQL duplication**. Includes a Navigator layer generator that builds a valid v4.5 JSON layer from covered technique IDs.
- **`lib/mcp/tools.ts`** — registers ~25 tools on the passed `McpServer` via Zod schemas. Groups: search & retrieval (`search`, `get_by_id`, `get_raw_yaml`, `list_all`), stats & coverage (`get_stats`, `get_coverage_summary`, `analyze_coverage`, `identify_gaps`, `get_technique_intelligence`, `get_technique_full`, `compare_sources`, `generate_navigator_layer`), filters (`list_by_source`, `list_by_severity`, `list_by_detection_type`, `list_by_mitre`, `list_by_mitre_tactic`, `list_by_cve`, `list_by_process_name`, `list_by_data_source`, `list_by_analytic_story`), threat actors (`list_actors`, `get_actor_profile`, `analyze_actor_coverage`, `compare_actor_coverage`).
- **`app/api/mcp/[transport]/route.ts`** — creates the `mcp-handler` handler once at module load, wraps it with `withAuth` that validates the bearer before dispatching. Exported as `GET`/`POST`/`DELETE`.

### Token management UI
- **`/account/tokens` page** — lists active tokens with per-token daily quota progress bars, last-used date, total call count. Newly-created tokens are revealed exactly once in a dismissable card with copy-to-clipboard. Includes ready-to-paste Claude Desktop / Cursor / curl snippets for `detect.michaelhaag.org/api/mcp/http`.
- **`/api/account/tokens`** — `POST` creates (10-token cap per user, 64-char name cap), `GET` lists metadata (no secrets), `DELETE` revokes via `revoked_at` timestamp.
- **`/account` page** — gains a "HOSTED MCP TOKENS" card linking to `/account/tokens`.

### Marketing
- **`/mcp` page** — gains a new **"HOSTED MCP — ZERO SETUP"** section before the existing local-install guide, positioning both paths side by side. Hero updated to "RUN IT LOCALLY OR HOSTED" with a **Get Hosted Token** CTA alongside the existing Clone / npm buttons.

### Middleware
- `middleware.ts` matcher now excludes `/api/mcp` so Supabase session refresh doesn't run on bearer-authenticated MCP requests.

### Dependencies
- Adds `mcp-handler@^1.1.0`, `@modelcontextprotocol/sdk@^1.25.3`, `zod@^3.25.76` to `web/package.json`.

## Vercel limits considered

- **Function timeout** — `maxDuration = 60`. Indexed Supabase queries return in well under 1s, leaving a comfortable ceiling.
- **Response body** — 4.5 MB cap. List tools hard-cap `limit` at 100, search at 100.
- **Cold starts** — ~200–500 ms, acceptable.
- **No long-lived connections** — stateless Streamable HTTP, no SSE sessions, no Redis dependency.
- **Supabase egress** — token-gated access + per-token daily quotas cap it.

## Out of scope (non-goals)

- Stateful tools (knowledge graph, dynamic tables, templates, autonomous analysis) — need per-user schemas, future work.
- Stripe/billing upgrade flow — the `profiles.tier` column and higher quotas are already wired; upgrade UX is separate.
- OAuth-based MCP auth — bearer tokens work with every current MCP client.
- Replacing SQLite in the stdio npm package — that stays offline-first.

## Test plan

- [ ] Apply migration `014_mcp_tokens.sql` in Supabase (SQL editor or `supabase db push`)
- [ ] Deploy to Vercel preview; verify `/api/mcp/http` route is live and returns 401 without a token
- [ ] Sign in on the web app, visit `/account/tokens`, generate a token named "test"
- [ ] `curl -X POST https://<preview>/api/mcp/http -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` — expect ~25 tools
- [ ] `tools/call` for `search` with `{"query":"lsass"}` — expect detection results
- [ ] `tools/call` for `get_coverage_summary` — expect the full coverage JSON
- [ ] `tools/call` for `analyze_actor_coverage` with `{"actor_name":"APT29"}` — expect coverage breakdown
- [ ] `tools/call` for `generate_navigator_layer` with `{"source_type":"sigma"}` — expect valid Navigator v4.5 JSON
- [ ] Revoke the token in `/account/tokens`, retry the curl call — expect `-32001 Token has been revoked`
- [ ] Regenerate, hammer the endpoint past 200 calls — expect `-32003 Daily quota exceeded` on call 201
- [ ] Configure Claude Desktop with the hosted URL + token, restart, verify tools appear and a real prompt works
- [ ] Repeat with Cursor
- [ ] Regression: `/api/search`, `/api/chat`, `/api/coverage`, `/api/account` still work
- [ ] Regression: `npx security-detections-mcp` (stdio) still works unchanged

## Verification status

- ✅ `tsc --noEmit` passes
- ✅ `eslint` passes on all touched files
- ⚠️ `next build` not run in sandbox — Google Fonts network requests are blocked in the build environment. Not a code issue; will succeed on Vercel.

https://claude.ai/code/session_01G3R3gx99YenK1CtzxbvdsU