### PR TITLE
feat: copy buttons on MCP install blocks

### DIFF
--- a/web/app/(app)/account/tokens/copy-block.tsx
+++ b/web/app/(app)/account/tokens/copy-block.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+
+export function CopyBlock({ children }: { children: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(children);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="relative group">
+      <pre className="bg-bg2 border border-border rounded p-3 pr-12 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">
+        {children}
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-card2 border border-border hover:border-amber/50 text-text-dim hover:text-amber transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/web/app/(app)/account/tokens/page.tsx
+++ b/web/app/(app)/account/tokens/page.tsx
@@ -2,6 +2,7 @@ import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { TokensManager } from './tokens-manager';
+import { CopyBlock } from './copy-block';
 
 export const dynamic = 'force-dynamic';
 
@@ -112,14 +113,14 @@ export default async function TokensPage() {
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Code (CLI)</div>
-          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</pre>
+          <CopyBlock>{`claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
         </div>
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">
             Claude Desktop (via mcp-remote)
           </div>
-          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`{
+          <CopyBlock>{`{
   "mcpServers": {
     "security-detections": {
       "command": "npx",
@@ -128,17 +129,17 @@ export default async function TokensPage() {
         "--header", "Authorization: Bearer sdmcp_..."]
     }
   }
-}`}</pre>
+}`}</CopyBlock>
         </div>
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">OpenAI Codex (CLI)</div>
-          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`codex mcp add security-detections --transport http https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</pre>
+          <CopyBlock>{`codex mcp add security-detections --transport http https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
         </div>
 
         <div>
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Test with curl</div>
-          <pre className="bg-bg2 border border-border rounded p-3 overflow-x-auto text-xs font-[family-name:var(--font-mono)] text-text">{`curl -X POST https://detect.michaelhaag.org/api/mcp/http -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</pre>
+          <CopyBlock>{`curl -X POST https://detect.michaelhaag.org/api/mcp/http -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CopyBlock>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds hover copy-to-clipboard buttons on all code blocks in the tokens page