### PR TITLE
fix: correct MCP endpoint URL to /api/mcp/mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An MCP (Model Context Protocol) server that lets LLMs query a unified database o
 
 **Local (full power)** — the npm package you're looking at. Runs on your machine, indexes your own detection repos, exposes all 81 tools. You need Node.js and ~10 minutes.
 
-**Hosted (zero setup)** — a Streamable HTTP server at [`detect.michaelhaag.org/api/mcp/http`](https://detect.michaelhaag.org/mcp). Sign up, generate a token, paste one URL into your MCP client. ~25 read-only tools, always in sync with the latest content, 200 calls/day free. Read on for quick-install buttons.
+**Hosted (zero setup)** — a Streamable HTTP server at [`detect.michaelhaag.org/api/mcp/mcp`](https://detect.michaelhaag.org/mcp). Sign up, generate a token, paste one URL into your MCP client. ~25 read-only tools, always in sync with the latest content, 200 calls/day free. Read on for quick-install buttons.
 
 ### Install — Local (Cursor)
 
@@ -29,7 +29,7 @@ An MCP (Model Context Protocol) server that lets LLMs query a unified database o
 
 ```bash
 claude mcp add --transport http security-detections \
-  https://detect.michaelhaag.org/api/mcp/http \
+  https://detect.michaelhaag.org/api/mcp/mcp \
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 
@@ -43,7 +43,7 @@ claude mcp add --transport http security-detections \
       "args": [
         "-y",
         "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/http",
+        "https://detect.michaelhaag.org/api/mcp/mcp",
         "--header",
         "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
       ]
@@ -56,7 +56,7 @@ claude mcp add --transport http security-detections \
 
 ```bash
 codex mcp add security-detections \
-  --transport http https://detect.michaelhaag.org/api/mcp/http \
+  --transport http https://detect.michaelhaag.org/api/mcp/mcp \
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 

--- a/docs/HOSTED_MCP.md
+++ b/docs/HOSTED_MCP.md
@@ -1,6 +1,6 @@
 # Hosted MCP Setup Guide
 
-A fully managed, public-facing Security Detections MCP server at **[`https://detect.michaelhaag.org/api/mcp/http`](https://detect.michaelhaag.org/api/mcp/http)**. No install, no indexing, always in sync with the latest detection content — just generate a token and point your AI client at the URL.
+A fully managed, public-facing Security Detections MCP server at **[`https://detect.michaelhaag.org/api/mcp/mcp`](https://detect.michaelhaag.org/api/mcp/mcp)**. No install, no indexing, always in sync with the latest detection content — just generate a token and point your AI client at the URL.
 
 > **Prefer local?** The npm package is still the full-power option (81 tools, offline, unlimited). See the main [README](../README.md) and [SETUP.md](../SETUP.md). The hosted endpoint is additive — everything in the local package is untouched.
 
@@ -29,7 +29,7 @@ Your MCP client
      │
      │ HTTPS — Authorization: Bearer sdmcp_xxx
      ▼
-/api/mcp/http  (Next.js route on Vercel, Streamable HTTP, stateless)
+/api/mcp/mcp  (Next.js route on Vercel, Streamable HTTP, stateless)
      │
      │ token hash → atomic rate-limit RPC
      ▼
@@ -66,7 +66,7 @@ After clicking, edit the installed server in **Cursor → Settings → MCP** and
 {
   "mcpServers": {
     "security-detections": {
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "url": "https://detect.michaelhaag.org/api/mcp/mcp",
       "headers": {
         "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
       }
@@ -89,7 +89,7 @@ After clicking, edit the installed server in VS Code and replace the placeholder
   "servers": {
     "security-detections": {
       "type": "http",
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "url": "https://detect.michaelhaag.org/api/mcp/mcp",
       "headers": {
         "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
       }
@@ -102,7 +102,7 @@ After clicking, edit the installed server in VS Code and replace the placeholder
 
 ```bash
 claude mcp add --transport http security-detections \
-  https://detect.michaelhaag.org/api/mcp/http \
+  https://detect.michaelhaag.org/api/mcp/mcp \
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 
@@ -113,7 +113,7 @@ Verify with `claude mcp list`, then start Claude Code — the tools will be avai
   "mcpServers": {
     "security-detections": {
       "type": "http",
-      "url": "https://detect.michaelhaag.org/api/mcp/http",
+      "url": "https://detect.michaelhaag.org/api/mcp/mcp",
       "headers": {
         "Authorization": "Bearer sdmcp_YOUR_TOKEN_HERE"
       }
@@ -138,7 +138,7 @@ Claude Desktop (the Mac/Windows app) only speaks **stdio** MCP natively, not rem
       "args": [
         "-y",
         "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/http",
+        "https://detect.michaelhaag.org/api/mcp/mcp",
         "--header",
         "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
       ]
@@ -157,7 +157,7 @@ Codex CLI and IDE extension support Streamable HTTP remote servers natively.
 
 ```bash
 codex mcp add security-detections \
-  --transport http https://detect.michaelhaag.org/api/mcp/http \
+  --transport http https://detect.michaelhaag.org/api/mcp/mcp \
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 
@@ -166,7 +166,7 @@ codex mcp add security-detections \
 ```toml
 [mcp_servers.security-detections]
 type = "http"
-url = "https://detect.michaelhaag.org/api/mcp/http"
+url = "https://detect.michaelhaag.org/api/mcp/mcp"
 headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }
 ```
 
@@ -174,7 +174,7 @@ headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }
 
 Any client that speaks MCP Streamable HTTP (2025-03-26 spec or newer) will work. Give it:
 
-- **URL:** `https://detect.michaelhaag.org/api/mcp/http`
+- **URL:** `https://detect.michaelhaag.org/api/mcp/mcp`
 - **Header:** `Authorization: Bearer sdmcp_YOUR_TOKEN_HERE`
 - **Transport:** Streamable HTTP, stateless (no `Mcp-Session-Id` required)
 - **Protocol version:** The server negotiates up to `2025-11-25`; it accepts `2025-03-26`, `2025-06-18`, `2025-11-25`.
@@ -185,14 +185,14 @@ Before wiring up a client, smoke-test the endpoint with `curl`:
 
 ```bash
 # List tools (should return ~25 tools)
-curl -X POST https://detect.michaelhaag.org/api/mcp/http \
+curl -X POST https://detect.michaelhaag.org/api/mcp/mcp \
   -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
 # Call a tool
-curl -X POST https://detect.michaelhaag.org/api/mcp/http \
+curl -X POST https://detect.michaelhaag.org/api/mcp/mcp \
   -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \

--- a/web/app/(app)/account/page.tsx
+++ b/web/app/(app)/account/page.tsx
@@ -93,7 +93,7 @@ export default async function AccountPage() {
         </h2>
         <p className="text-text-dim text-sm mb-4">
           Generate a token to connect your AI assistant (Claude Desktop, Cursor, Claude Code) directly to{' '}
-          <code className="text-amber font-[family-name:var(--font-mono)]">detect.michaelhaag.org/api/mcp/http</code>.
+          <code className="text-amber font-[family-name:var(--font-mono)]">detect.michaelhaag.org/api/mcp/mcp</code>.
           No install required.
         </p>
         <Link

--- a/web/app/(app)/account/tokens/page.tsx
+++ b/web/app/(app)/account/tokens/page.tsx
@@ -54,7 +54,7 @@ export default async function TokensPage() {
       <p className="text-text-dim text-sm mb-8">
         Generate tokens to connect your AI client to the hosted Security Detections MCP at{' '}
         <code className="bg-bg2 px-2 py-0.5 rounded font-[family-name:var(--font-mono)] text-amber">
-          detect.michaelhaag.org/api/mcp/http
+          detect.michaelhaag.org/api/mcp/mcp
         </code>
       </p>
 
@@ -94,7 +94,7 @@ export default async function TokensPage() {
         {/* One-click install buttons */}
         <div className="grid grid-cols-2 gap-2 mb-5">
           <a
-            href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9odHRwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIHNkbWNwX1lPVVJfVE9LRU5fSEVSRSJ9fQ=="
+            href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgc2RtY3BfWU9VUl9UT0tFTl9IRVJFIn19"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
@@ -103,7 +103,7 @@ export default async function TokensPage() {
             <span className="text-amber text-xs">&rarr;</span>
           </a>
           <a
-            href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fhttp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+            href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A//detect.michaelhaag.org/api/mcp/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
             className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
           >
             <span className="text-text-bright font-bold text-xs">Install in VS Code</span>
@@ -113,7 +113,7 @@ export default async function TokensPage() {
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Code (CLI)</div>
-          <CopyBlock>{`claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
+          <CopyBlock>{`claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
         </div>
 
         <div className="mb-5">
@@ -125,7 +125,7 @@ export default async function TokensPage() {
     "security-detections": {
       "command": "npx",
       "args": ["-y", "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/http",
+        "https://detect.michaelhaag.org/api/mcp/mcp",
         "--header", "Authorization: Bearer sdmcp_..."]
     }
   }
@@ -134,12 +134,12 @@ export default async function TokensPage() {
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">OpenAI Codex (CLI)</div>
-          <CopyBlock>{`codex mcp add security-detections --transport http https://detect.michaelhaag.org/api/mcp/http --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
+          <CopyBlock>{`codex mcp add security-detections --transport http https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
         </div>
 
         <div>
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Test with curl</div>
-          <CopyBlock>{`curl -X POST https://detect.michaelhaag.org/api/mcp/http -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CopyBlock>
+          <CopyBlock>{`curl -X POST https://detect.michaelhaag.org/api/mcp/mcp -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CopyBlock>
         </div>
       </div>
     </div>

--- a/web/app/api/well-known/oauth-protected-resource/route.ts
+++ b/web/app/api/well-known/oauth-protected-resource/route.ts
@@ -30,7 +30,7 @@ function baseUrl(request: Request): string {
 export async function GET(request: Request): Promise<Response> {
   const origin = baseUrl(request);
   const metadata = {
-    resource: `${origin}/api/mcp/http`,
+    resource: `${origin}/api/mcp/mcp`,
     authorization_servers: [] as string[],
     bearer_methods_supported: ['header'],
     resource_name: 'Security Detections MCP',

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -213,7 +213,7 @@ export default function McpSetupPage() {
               <div className="mt-6">
                 <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Code (CLI one-liner)</div>
                 <CodeBlock title="Terminal" lang="bash">{`claude mcp add --transport http security-detections \\
-  https://detect.michaelhaag.org/api/mcp/http \\
+  https://detect.michaelhaag.org/api/mcp/mcp \\
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
               </div>
 
@@ -230,7 +230,7 @@ export default function McpSetupPage() {
       "args": [
         "-y",
         "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/http",
+        "https://detect.michaelhaag.org/api/mcp/mcp",
         "--header",
         "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
       ]
@@ -243,21 +243,21 @@ export default function McpSetupPage() {
               <div className="mt-4">
                 <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">OpenAI Codex</div>
                 <CodeBlock title="Terminal" lang="bash">{`codex mcp add security-detections \\
-  --transport http https://detect.michaelhaag.org/api/mcp/http \\
+  --transport http https://detect.michaelhaag.org/api/mcp/mcp \\
   --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
                 <p className="text-text-dim text-xs mt-2">
                   Or edit <code className="text-amber">~/.codex/config.toml</code>:
                 </p>
                 <CodeBlock title="~/.codex/config.toml" lang="toml">{`[mcp_servers.security-detections]
 type = "http"
-url = "https://detect.michaelhaag.org/api/mcp/http"
+url = "https://detect.michaelhaag.org/api/mcp/mcp"
 headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }`}</CodeBlock>
               </div>
 
               {/* Test with curl */}
               <div className="mt-4">
                 <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Verify with curl</div>
-                <CodeBlock title="Terminal" lang="bash">{`curl -X POST https://detect.michaelhaag.org/api/mcp/http \\
+                <CodeBlock title="Terminal" lang="bash">{`curl -X POST https://detect.michaelhaag.org/api/mcp/mcp \\
   -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \\
   -H "Accept: application/json, text/event-stream" \\
   -H "Content-Type: application/json" \\


### PR DESCRIPTION
mcp-handler routes Streamable HTTP at basePath+/mcp, not /http. Fixes 'Not found' on production.