### PR TITLE
chore: sync main with npm 3.2.1 (README + version bump)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "security-detections-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "security-detections-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "security-detections-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Advanced MCP server for security detections with Detection Engineering Intelligence, Knowledge Graph (Tribal Knowledge), Elicitation, and Resource Subscriptions",
   "sigmaSpecVersion": "2.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version to 3.2.1 (already published to npm)
- Fix hosted MCP URLs from `/api/mcp/http` → `/api/mcp/mcp`
- Add VS Code + VS Code Insiders install buttons for local MCP
- Add Claude Code CLI one-liner for local install

Syncs the GitHub README with what's already live on [npmjs](https://www.npmjs.com/package/security-detections-mcp).