### PR TITLE
Align hosted install links and commands across docs and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ codex mcp add security-detections -- npx -y security-detections-mcp
 **Claude Code** (CLI one-liner):
 
 ```bash
-claude mcp add --transport http security-detections \
-  https://detect.michaelhaag.org/api/mcp/mcp \
-  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 
 **Claude Desktop** (via [`mcp-remote`](https://github.com/geelen/mcp-remote) — Desktop doesn't speak remote HTTP natively yet):
@@ -84,10 +82,7 @@ claude mcp add --transport http security-detections \
 **OpenAI Codex** (CLI):
 
 ```bash
-# Set your token as an env var first: export SDMCP_TOKEN="sdmcp_YOUR_TOKEN_HERE"
-codex mcp add security-detections \
-  --url https://detect.michaelhaag.org/api/mcp/mcp \
-  --bearer-token-env-var SDMCP_TOKEN
+export SDMCP_TOKEN="sdmcp_YOUR_TOKEN_HERE" && codex mcp add security-detections --url https://detect.michaelhaag.org/api/mcp/mcp --bearer-token-env-var SDMCP_TOKEN
 ```
 
 See the [Hosted MCP Setup Guide](./docs/HOSTED_MCP.md) for the full table of clients, the complete tool inventory, and troubleshooting tips.

--- a/docs/HOSTED_MCP.md
+++ b/docs/HOSTED_MCP.md
@@ -79,8 +79,8 @@ After clicking, edit the installed server in **Cursor → Settings → MCP** and
 
 One-click install (opens VS Code):
 
-- **[Install in VS Code →](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A//detect.michaelhaag.org/api/mcp/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
-- **[Install in VS Code Insiders →](https://insiders.vscode.dev/redirect?url=vscode-insiders:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A//detect.michaelhaag.org/api/mcp/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
+- **[Install in VS Code →](https://vscode.dev/redirect?url=vscode:mcp/install?name=security-detections&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
+- **[Install in VS Code Insiders →](https://insiders.vscode.dev/redirect?url=vscode-insiders:mcp/install?name=security-detections&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D)**
 
 After clicking, edit the installed server in VS Code and replace the placeholder token. Or edit your MCP config directly:
 
@@ -101,9 +101,7 @@ After clicking, edit the installed server in VS Code and replace the placeholder
 ### Claude Code CLI
 
 ```bash
-claude mcp add --transport http security-detections \
-  https://detect.michaelhaag.org/api/mcp/mcp \
-  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
 ```
 
 Verify with `claude mcp list`, then start Claude Code — the tools will be available. `.mcp.json` equivalent:
@@ -156,18 +154,17 @@ Codex CLI and IDE extension support Streamable HTTP remote servers natively.
 **CLI one-liner:**
 
 ```bash
-codex mcp add security-detections \
-  --transport http https://detect.michaelhaag.org/api/mcp/mcp \
-  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+export SDMCP_TOKEN="sdmcp_YOUR_TOKEN_HERE" && codex mcp add security-detections --url https://detect.michaelhaag.org/api/mcp/mcp --bearer-token-env-var SDMCP_TOKEN
 ```
+
+Set `SDMCP_TOKEN` in your shell profile so Codex can read it in future sessions.
 
 **Config file** — `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.security-detections]
-type = "http"
 url = "https://detect.michaelhaag.org/api/mcp/mcp"
-headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }
+bearer_token_env_var = "SDMCP_TOKEN"
 ```
 
 ### Any other MCP client

--- a/web/app/(app)/account/tokens/page.tsx
+++ b/web/app/(app)/account/tokens/page.tsx
@@ -3,6 +3,13 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { TokensManager } from './tokens-manager';
 import { CopyBlock } from './copy-block';
+import {
+  HOSTED_CODEX_TOKEN_ENV_VAR,
+  HOSTED_CURSOR_INSTALL_URL,
+  HOSTED_MCP_URL,
+  HOSTED_TOKEN_PLACEHOLDER,
+  HOSTED_VSCODE_INSTALL_URL,
+} from '@/lib/mcp/install-links';
 
 export const dynamic = 'force-dynamic';
 
@@ -61,7 +68,7 @@ export default async function TokensPage() {
       <p className="text-text-dim text-sm mb-8">
         Generate tokens to connect your AI client to the hosted Security Detections MCP at{' '}
         <code className="bg-bg2 px-2 py-0.5 rounded font-[family-name:var(--font-mono)] text-amber">
-          detect.michaelhaag.org/api/mcp/mcp
+          {HOSTED_MCP_URL.replace(/^https?:\/\//, '')}
         </code>
       </p>
 
@@ -101,7 +108,7 @@ export default async function TokensPage() {
         {/* One-click install buttons */}
         <div className="grid grid-cols-2 gap-2 mb-5">
           <a
-            href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgc2RtY3BfWU9VUl9UT0tFTl9IRVJFIn19"
+            href={HOSTED_CURSOR_INSTALL_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
@@ -110,7 +117,9 @@ export default async function TokensPage() {
             <span className="text-amber text-xs">&rarr;</span>
           </a>
           <a
-            href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A//detect.michaelhaag.org/api/mcp/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+            href={HOSTED_VSCODE_INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
             className="flex items-center justify-between bg-bg2 hover:bg-card2 border border-border hover:border-amber/50 rounded px-3 py-2 transition-colors"
           >
             <span className="text-text-bright font-bold text-xs">Install in VS Code</span>
@@ -120,7 +129,7 @@ export default async function TokensPage() {
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Claude Code (CLI)</div>
-          <CopyBlock>{`claude mcp add --transport http security-detections https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
+          <CopyBlock>{`claude mcp add --transport http security-detections ${HOSTED_MCP_URL} --header "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}"`}</CopyBlock>
         </div>
 
         <div className="mb-5">
@@ -132,8 +141,8 @@ export default async function TokensPage() {
     "security-detections": {
       "command": "npx",
       "args": ["-y", "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/mcp",
-        "--header", "Authorization: Bearer sdmcp_..."]
+        "${HOSTED_MCP_URL}",
+        "--header", "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}"]
     }
   }
 }`}</CopyBlock>
@@ -141,12 +150,15 @@ export default async function TokensPage() {
 
         <div className="mb-5">
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">OpenAI Codex (CLI)</div>
-          <CopyBlock>{`codex mcp add security-detections --transport http https://detect.michaelhaag.org/api/mcp/mcp --header "Authorization: Bearer sdmcp_..."`}</CopyBlock>
+          <CopyBlock>{`export ${HOSTED_CODEX_TOKEN_ENV_VAR}="${HOSTED_TOKEN_PLACEHOLDER}" && codex mcp add security-detections --url ${HOSTED_MCP_URL} --bearer-token-env-var ${HOSTED_CODEX_TOKEN_ENV_VAR}`}</CopyBlock>
+          <p className="text-text-dim text-xs mt-2">
+            Keep <code className="text-amber">{HOSTED_CODEX_TOKEN_ENV_VAR}</code> set in your shell profile so Codex can use the token in new sessions.
+          </p>
         </div>
 
         <div>
           <div className="text-amber font-[family-name:var(--font-mono)] text-xs font-bold mb-2">Test with curl</div>
-          <CopyBlock>{`curl -X POST https://detect.michaelhaag.org/api/mcp/mcp -H "Authorization: Bearer sdmcp_..." -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CopyBlock>
+          <CopyBlock>{`curl -X POST ${HOSTED_MCP_URL} -H "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}" -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CopyBlock>
         </div>
       </div>
     </div>

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -1,4 +1,12 @@
 import Link from 'next/link';
+import {
+  HOSTED_CODEX_TOKEN_ENV_VAR,
+  HOSTED_CURSOR_INSTALL_URL,
+  HOSTED_MCP_URL,
+  HOSTED_TOKEN_PLACEHOLDER,
+  HOSTED_VSCODE_INSIDERS_INSTALL_URL,
+  HOSTED_VSCODE_INSTALL_URL,
+} from '@/lib/mcp/install-links';
 
 function Step({ number, title, children }: { number: number; title: string; children: React.ReactNode }) {
   return (
@@ -160,7 +168,7 @@ export default function McpSetupPage() {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
                 {/* Cursor */}
                 <a
-                  href="https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgc2RtY3BfWU9VUl9UT0tFTl9IRVJFIn19"
+                  href={HOSTED_CURSOR_INSTALL_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border-bright hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
@@ -174,7 +182,9 @@ export default function McpSetupPage() {
 
                 {/* VS Code */}
                 <a
-                  href="vscode:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+                  href={HOSTED_VSCODE_INSTALL_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border-bright hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
                 >
                   <div>
@@ -186,7 +196,9 @@ export default function McpSetupPage() {
 
                 {/* VS Code Insiders */}
                 <a
-                  href="vscode-insiders:mcp/install?%7B%22name%22%3A%22security-detections%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D"
+                  href={HOSTED_VSCODE_INSIDERS_INSTALL_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="flex items-center justify-between gap-3 bg-card hover:bg-card2 border border-border hover:border-amber/50 rounded-[var(--radius-button)] px-4 py-3 transition-colors"
                 >
                   <div>
@@ -212,9 +224,7 @@ export default function McpSetupPage() {
               {/* Claude Code CLI */}
               <div className="mt-6">
                 <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Claude Code (CLI one-liner)</div>
-                <CodeBlock title="Terminal" lang="bash">{`claude mcp add --transport http security-detections \\
-  https://detect.michaelhaag.org/api/mcp/mcp \\
-  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
+                <CodeBlock title="Terminal" lang="bash">{`claude mcp add --transport http security-detections ${HOSTED_MCP_URL} --header "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}"`}</CodeBlock>
               </div>
 
               {/* Claude Desktop via mcp-remote */}
@@ -230,9 +240,9 @@ export default function McpSetupPage() {
       "args": [
         "-y",
         "mcp-remote",
-        "https://detect.michaelhaag.org/api/mcp/mcp",
+        "${HOSTED_MCP_URL}",
         "--header",
-        "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"
+        "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}"
       ]
     }
   }
@@ -241,27 +251,23 @@ export default function McpSetupPage() {
 
               {/* OpenAI Codex */}
               <div className="mt-4">
-                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">OpenAI Codex</div>
-                <CodeBlock title="Terminal" lang="bash">{`codex mcp add security-detections \\
-  --transport http https://detect.michaelhaag.org/api/mcp/mcp \\
-  --header "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE"`}</CodeBlock>
+                <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">OpenAI Codex (CLI)</div>
+                <CodeBlock title="Terminal" lang="bash">{`export ${HOSTED_CODEX_TOKEN_ENV_VAR}="${HOSTED_TOKEN_PLACEHOLDER}" && codex mcp add security-detections --url ${HOSTED_MCP_URL} --bearer-token-env-var ${HOSTED_CODEX_TOKEN_ENV_VAR}`}</CodeBlock>
+                <p className="text-text-dim text-xs mt-2">
+                  Persist <code className="text-amber">{HOSTED_CODEX_TOKEN_ENV_VAR}</code> in your shell profile so Codex can read it in future sessions.
+                </p>
                 <p className="text-text-dim text-xs mt-2">
                   Or edit <code className="text-amber">~/.codex/config.toml</code>:
                 </p>
                 <CodeBlock title="~/.codex/config.toml" lang="toml">{`[mcp_servers.security-detections]
-type = "http"
-url = "https://detect.michaelhaag.org/api/mcp/mcp"
-headers = { Authorization = "Bearer sdmcp_YOUR_TOKEN_HERE" }`}</CodeBlock>
+url = "${HOSTED_MCP_URL}"
+bearer_token_env_var = "${HOSTED_CODEX_TOKEN_ENV_VAR}"`}</CodeBlock>
               </div>
 
               {/* Test with curl */}
               <div className="mt-4">
                 <div className="text-green font-[family-name:var(--font-mono)] text-sm font-bold mb-2">Verify with curl</div>
-                <CodeBlock title="Terminal" lang="bash">{`curl -X POST https://detect.michaelhaag.org/api/mcp/mcp \\
-  -H "Authorization: Bearer sdmcp_YOUR_TOKEN_HERE" \\
-  -H "Accept: application/json, text/event-stream" \\
-  -H "Content-Type: application/json" \\
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CodeBlock>
+                <CodeBlock title="Terminal" lang="bash">{`curl -X POST ${HOSTED_MCP_URL} -H "Authorization: Bearer ${HOSTED_TOKEN_PLACEHOLDER}" -H "Accept: application/json, text/event-stream" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`}</CodeBlock>
               </div>
             </Step>
 

--- a/web/lib/mcp/install-links.ts
+++ b/web/lib/mcp/install-links.ts
@@ -1,0 +1,12 @@
+export const HOSTED_MCP_URL = 'https://detect.michaelhaag.org/api/mcp/mcp';
+export const HOSTED_TOKEN_PLACEHOLDER = 'sdmcp_YOUR_TOKEN_HERE';
+export const HOSTED_CODEX_TOKEN_ENV_VAR = 'SDMCP_TOKEN';
+
+export const HOSTED_CURSOR_INSTALL_URL =
+  'https://cursor.com/en/install-mcp?name=security-detections-hosted&config=eyJ1cmwiOiJodHRwczovL2RldGVjdC5taWNoYWVsaGFhZy5vcmcvYXBpL21jcC9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgc2RtY3BfWU9VUl9UT0tFTl9IRVJFIn19';
+
+export const HOSTED_VSCODE_INSTALL_URL =
+  'https://vscode.dev/redirect?url=vscode:mcp/install?name=security-detections&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D';
+
+export const HOSTED_VSCODE_INSIDERS_INSTALL_URL =
+  'https://insiders.vscode.dev/redirect?url=vscode-insiders:mcp/install?name=security-detections&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdetect.michaelhaag.org%2Fapi%2Fmcp%2Fmcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22Bearer%20sdmcp_YOUR_TOKEN_HERE%22%7D%7D';


### PR DESCRIPTION
## Summary
- Align hosted one-click install links in web UI with README/docs (Cursor + VS Code + VS Code Insiders)
- Add shared hosted install-link constants in `web/lib/mcp/install-links.ts` to prevent drift
- Make `/mcp` hosted CLI snippets one-line and update Codex setup to current CLI syntax (`--url` + `--bearer-token-env-var`)
- Update `/account/tokens` snippets to match the same hosted endpoint placeholders and Codex syntax
- Sync `docs/HOSTED_MCP.md` and hosted README snippets with the same deep links and command examples

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run lint`
