### PR TITLE
Show active chat model and document model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,41 @@ export SDMCP_TOKEN="sdmcp_YOUR_TOKEN_HERE" && codex mcp add security-detections 
 
 See the [Hosted MCP Setup Guide](./docs/HOSTED_MCP.md) for the full table of clients, the complete tool inventory, and troubleshooting tips.
 
+## AI Model Routing (Web App)
+
+The web chat supports Free, Pro/Admin, and BYOK (Bring Your Own Key) routing. You can also see the active model at the top of the chat UI.
+
+### Free Tier (default)
+
+- Default model: `nvidia/nemotron-3-super-120b-a12b:free`
+- Automatic fallback order if the first model is busy:
+  1. `nvidia/nemotron-3-super-120b-a12b:free`
+  2. `nousresearch/hermes-3-llama-3.1-405b:free`
+  3. `meta-llama/llama-3.3-70b-instruct:free`
+  4. `openai/gpt-oss-120b:free`
+
+### Pro/Admin (no BYOK key set)
+
+Uses app-managed OpenRouter routing with your **Preferred Model** setting in `/account`:
+
+| Preferred Model | Routed model |
+|---|---|
+| `auto` | `anthropic/claude-sonnet-4-6` |
+| `claude` | `anthropic/claude-sonnet-4-6` |
+| `claude-opus` | `anthropic/claude-opus-4-6` |
+| `gpt` | `openai/gpt-5.4` |
+| `gpt-codex` | `openai/gpt-5.3-codex` |
+
+### BYOK behavior (takes precedence over tier routing)
+
+If you set your own API key(s), routing priority is:
+
+1. Claude key (`sk-ant-...`) -> `claude-sonnet-4-6-20250514` via Anthropic
+2. OpenAI key (`sk-...`) -> `gpt-5.4` via OpenAI
+3. OpenRouter key (`sk-or-...`) -> uses the same Preferred Model mapping table above
+
+If multiple keys are present, the first match in that order is used.
+
 ## Features
 
 - **8,200+ detections** across 6 formats — Sigma, Splunk ESCU, Elastic, KQL, Sublime, CrowdStrike CQL

--- a/web/app/(app)/chat/page.tsx
+++ b/web/app/(app)/chat/page.tsx
@@ -16,16 +16,28 @@ interface Conversation {
   updated_at: string;
 }
 
+interface ModelStatus {
+  provider: string;
+  source: string;
+  model: string;
+  label: string;
+  note?: string;
+  fallback_models?: string[];
+  used_model?: string;
+}
+
 export default function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const supabase = createClient();
 
   useEffect(() => {
+    loadModelStatus();
     loadConversations();
     const params = new URLSearchParams(window.location.search);
     const convId = params.get('c');
@@ -59,6 +71,17 @@ export default function ChatPage() {
         role: m.role as 'user' | 'assistant',
         content: m.content,
       })));
+    }
+  }
+
+  async function loadModelStatus() {
+    try {
+      const response = await fetch('/api/chat', { method: 'GET' });
+      if (!response.ok) return;
+      const data = await response.json();
+      setModelStatus(data);
+    } catch {
+      // Non-fatal: model badge will stay unset.
     }
   }
 
@@ -121,6 +144,24 @@ export default function ChatPage() {
           })),
         }),
       });
+
+      const modelProvider = response.headers.get('X-Model-Provider');
+      const modelSource = response.headers.get('X-Model-Source');
+      const modelSelected = response.headers.get('X-Model-Selected');
+      const modelUsed = response.headers.get('X-Model-Used');
+      const modelLabel = response.headers.get('X-Model-Label');
+
+      if (modelProvider && modelSource && modelSelected && modelLabel) {
+        setModelStatus(prev => ({
+          provider: modelProvider,
+          source: modelSource,
+          model: modelSelected,
+          label: modelLabel,
+          note: prev?.note,
+          fallback_models: prev?.fallback_models,
+          used_model: modelUsed || modelSelected,
+        }));
+      }
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -185,6 +226,18 @@ export default function ChatPage() {
     }
   }
 
+  function sourceLabel(source?: string): string {
+    switch (source) {
+      case 'byok-claude': return 'BYOK Claude';
+      case 'byok-openai': return 'BYOK OpenAI';
+      case 'byok-openrouter': return 'BYOK OpenRouter';
+      case 'pro': return 'Pro';
+      case 'admin': return 'Admin';
+      case 'free': return 'Free';
+      default: return 'Unknown';
+    }
+  }
+
   return (
     <div className="flex h-[calc(100vh-8rem)] max-w-6xl mx-auto gap-4">
       {/* Chat history sidebar */}
@@ -220,6 +273,28 @@ export default function ChatPage() {
 
       {/* Main chat area */}
       <div className="flex-1 flex flex-col min-w-0">
+        <div className="mb-3 bg-card border border-border rounded-[var(--radius-card)] px-4 py-2.5">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="text-text-dim text-xs uppercase font-[family-name:var(--font-mono)] tracking-wider">Active AI Model</span>
+            <span className="text-text text-sm font-semibold">
+              {modelStatus?.used_model === 'db-only'
+                ? 'Database-only (no LLM used)'
+                : (modelStatus?.label || 'Detecting...')}
+            </span>
+            <span className="text-amber text-xs font-[family-name:var(--font-mono)]">
+              {modelStatus ? sourceLabel(modelStatus.source) : ''}
+            </span>
+          </div>
+          {modelStatus?.used_model && modelStatus.used_model !== 'db-only' && modelStatus.used_model !== modelStatus.model && (
+            <p className="text-text-dim text-xs mt-1">
+              Last response used fallback model: <code className="text-amber">{modelStatus.used_model}</code>
+            </p>
+          )}
+          {modelStatus?.note && (
+            <p className="text-text-dim text-xs mt-1">{modelStatus.note}</p>
+          )}
+        </div>
+
         {/* Messages */}
         <div className="flex-1 overflow-y-auto space-y-4 pb-4">
           {messages.length === 0 && (

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -1,10 +1,43 @@
 import { NextRequest } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createServiceClient } from '@/lib/supabase/server';
-import { getModelConfig, getRateLimit } from '@/lib/ai/router';
+import { getModelConfig, getModelRoutingInfo, getRateLimit } from '@/lib/ai/router';
 import { buildSystemPrompt } from '@/lib/ai/system-prompt';
 import { AI_TOOLS } from '@/lib/ai/tools';
 import { executeToolCall } from '@/lib/ai/tool-executor';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const serviceClient = await createServiceClient();
+    const { data: profile } = await serviceClient
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single();
+
+    const modelInfo = getModelRoutingInfo(profile);
+    return Response.json({
+      provider: modelInfo.provider,
+      source: modelInfo.source,
+      model: modelInfo.model,
+      label: modelInfo.modelLabel,
+      note: modelInfo.note,
+      fallback_models: modelInfo.fallbackModels ?? [],
+    });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -88,7 +121,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const modelInfo = getModelRoutingInfo(profile);
     const modelConfig = getModelConfig(profile);
+    let modelUsed = modelInfo.model;
     const isFree = profile?.tier !== 'pro' && profile?.tier !== 'admin' && !profile?.claude_api_key_encrypted && !profile?.openai_api_key_encrypted && !profile?.openrouter_api_key_encrypted;
 
     // For free tier: pre-fetch relevant data and inject into context (free models don't support tool calling)
@@ -126,12 +161,16 @@ Write a brief 2-3 sentence analysis of this data. Focus on: what looks good, wha
           const data = await response.json();
           if (!data.error && data.choices?.[0]?.message?.content) {
             aiAnalysis = data.choices[0].message.content;
+            modelUsed = freeModel;
             break;
           }
         }
 
         // Combine: data report first (always accurate), then AI analysis
         content = dataReport + (aiAnalysis ? `\n\n---\n\n**Analysis**\n\n${aiAnalysis}` : '');
+        if (!aiAnalysis) {
+          modelUsed = 'db-only';
+        }
       } else {
         // General/conversational query — use AI with context
         const contextData = await prefetchContext(lastUserMsg);
@@ -152,6 +191,7 @@ Write a brief 2-3 sentence analysis of this data. Focus on: what looks good, wha
           const data = await response.json();
           if (!data.error) {
             responseData = data;
+            modelUsed = freeModel;
             break;
           }
         }
@@ -243,6 +283,11 @@ Write a brief 2-3 sentence analysis of this data. Focus on: what looks good, wha
       headers: {
         'Content-Type': 'text/plain; charset=utf-8',
         'Cache-Control': 'no-cache',
+        'X-Model-Provider': modelInfo.provider,
+        'X-Model-Source': modelInfo.source,
+        'X-Model-Selected': modelInfo.model,
+        'X-Model-Used': modelUsed,
+        'X-Model-Label': modelInfo.modelLabel,
       },
     });
   } catch (error) {

--- a/web/lib/ai/router.ts
+++ b/web/lib/ai/router.ts
@@ -5,12 +5,29 @@ export interface ModelConfig {
   baseUrl: string;
 }
 
-interface UserProfile {
+export type ModelSource =
+  | 'byok-claude'
+  | 'byok-openai'
+  | 'byok-openrouter'
+  | 'pro'
+  | 'admin'
+  | 'free';
+
+export interface UserProfile {
   tier: string;
   preferred_model: string;
   openrouter_api_key_encrypted: string | null;
   claude_api_key_encrypted: string | null;
   openai_api_key_encrypted: string | null;
+}
+
+export interface ModelRoutingInfo {
+  source: ModelSource;
+  provider: 'openrouter' | 'anthropic' | 'openai';
+  model: string;
+  modelLabel: string;
+  note?: string;
+  fallbackModels?: string[];
 }
 
 // Free tier models — ordered by quality for instruction following + context fidelity
@@ -34,54 +51,109 @@ const PRO_MODELS: Record<string, string> = {
 // Import decrypt — this module is only used server-side (chat API route)
 import { decrypt } from '@/lib/crypto';
 
-export function getModelConfig(profile: UserProfile | null): ModelConfig {
+const MODEL_LABELS: Record<string, string> = {
+  'claude-sonnet-4-6-20250514': 'Claude Sonnet 4.6',
+  'anthropic/claude-sonnet-4-6': 'Claude Sonnet 4.6',
+  'anthropic/claude-opus-4-6': 'Claude Opus 4.6',
+  'gpt-5.4': 'GPT-5.4',
+  'openai/gpt-5.4': 'GPT-5.4',
+  'openai/gpt-5.3-codex': 'GPT-5.3 Codex',
+  'nvidia/nemotron-3-super-120b-a12b:free': 'Nemotron 3 Super 120B (Free)',
+  'nousresearch/hermes-3-llama-3.1-405b:free': 'Hermes 3 Llama 405B (Free)',
+  'meta-llama/llama-3.3-70b-instruct:free': 'Llama 3.3 70B Instruct (Free)',
+  'openai/gpt-oss-120b:free': 'GPT-OSS 120B (Free)',
+};
 
-  // BYOK: User has their own Claude API key
+function getModelLabel(model: string): string {
+  return MODEL_LABELS[model] || model;
+}
+
+export function getModelRoutingInfo(profile: UserProfile | null): ModelRoutingInfo {
   if (profile?.claude_api_key_encrypted) {
     return {
+      source: 'byok-claude',
       provider: 'anthropic',
       model: 'claude-sonnet-4-6-20250514',
-      apiKey: decrypt(profile.claude_api_key_encrypted),
+      modelLabel: getModelLabel('claude-sonnet-4-6-20250514'),
+      note: 'Using your Claude API key',
+    };
+  }
+
+  if (profile?.openai_api_key_encrypted) {
+    return {
+      source: 'byok-openai',
+      provider: 'openai',
+      model: 'gpt-5.4',
+      modelLabel: getModelLabel('gpt-5.4'),
+      note: 'Using your OpenAI API key',
+    };
+  }
+
+  if (profile?.openrouter_api_key_encrypted) {
+    const model = PRO_MODELS[profile.preferred_model] || PRO_MODELS['auto'];
+    return {
+      source: 'byok-openrouter',
+      provider: 'openrouter',
+      model,
+      modelLabel: getModelLabel(model),
+      note: 'Using your OpenRouter API key',
+    };
+  }
+
+  if (profile?.tier === 'pro' || profile?.tier === 'admin') {
+    const model = PRO_MODELS[profile.preferred_model] || PRO_MODELS['auto'];
+    return {
+      source: profile.tier === 'admin' ? 'admin' : 'pro',
+      provider: 'openrouter',
+      model,
+      modelLabel: getModelLabel(model),
+      note: 'Using app-managed frontier model routing',
+    };
+  }
+
+  return {
+    source: 'free',
+    provider: 'openrouter',
+    model: FREE_MODEL,
+    modelLabel: getModelLabel(FREE_MODEL),
+    note: 'Free tier uses automatic fallback across free models',
+    fallbackModels: FREE_MODELS,
+  };
+}
+
+export function getModelConfig(profile: UserProfile | null): ModelConfig {
+  const routing = getModelRoutingInfo(profile);
+
+  if (routing.source === 'byok-claude') {
+    return {
+      provider: 'anthropic',
+      model: routing.model,
+      apiKey: decrypt(profile!.claude_api_key_encrypted!),
       baseUrl: 'https://api.anthropic.com/v1',
     };
   }
 
-  // BYOK: User has their own OpenAI API key
-  if (profile?.openai_api_key_encrypted) {
+  if (routing.source === 'byok-openai') {
     return {
       provider: 'openai',
-      model: 'gpt-5.4',
-      apiKey: decrypt(profile.openai_api_key_encrypted),
+      model: routing.model,
+      apiKey: decrypt(profile!.openai_api_key_encrypted!),
       baseUrl: 'https://api.openai.com/v1',
     };
   }
 
-  // BYOK: User has their own OpenRouter API key
-  if (profile?.openrouter_api_key_encrypted) {
-    const model = PRO_MODELS[profile.preferred_model] || PRO_MODELS['auto'];
+  if (routing.source === 'byok-openrouter') {
     return {
       provider: 'openrouter',
-      model,
-      apiKey: decrypt(profile.openrouter_api_key_encrypted),
+      model: routing.model,
+      apiKey: decrypt(profile!.openrouter_api_key_encrypted!),
       baseUrl: 'https://openrouter.ai/api/v1',
     };
   }
 
-  // Pro/Admin tier: use app's OpenRouter key with frontier models
-  if (profile?.tier === 'pro' || profile?.tier === 'admin') {
-    const model = PRO_MODELS[profile.preferred_model] || PRO_MODELS['auto'];
-    return {
-      provider: 'openrouter',
-      model,
-      apiKey: process.env.OPENROUTER_API_KEY!,
-      baseUrl: 'https://openrouter.ai/api/v1',
-    };
-  }
-
-  // Free tier: OpenRouter free smart router
   return {
     provider: 'openrouter',
-    model: FREE_MODEL,
+    model: routing.model,
     apiKey: process.env.OPENROUTER_API_KEY!,
     baseUrl: 'https://openrouter.ai/api/v1',
   };


### PR DESCRIPTION
## Summary
- add active model indicator at the top of chat UI
- expose model routing metadata via `GET /api/chat`
- include model metadata headers on chat responses so UI can show selected vs actually used model
- track and display free-tier fallback model usage per response
- document free/pro/BYOK model routing in README

## Notes
- BYOK / Pro / Admin / Free source is shown in the badge
- Free tier still attempts the configured fallback model list in order

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run lint`
