### PR TITLE
Fix account Auto model label for free-tier routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Uses app-managed OpenRouter routing with your **Preferred Model** setting in `/a
 
 | Preferred Model | Routed model |
 |---|---|
-| `auto` | `anthropic/claude-sonnet-4-6` |
+| `auto` | Free model pool (default: `nvidia/nemotron-3-super-120b-a12b:free`) |
 | `claude` | `anthropic/claude-sonnet-4-6` |
 | `claude-opus` | `anthropic/claude-opus-4-6` |
 | `gpt` | `openai/gpt-5.4` |

--- a/web/app/(app)/account/account-form.tsx
+++ b/web/app/(app)/account/account-form.tsx
@@ -10,9 +10,10 @@ interface AccountFormProps {
   hasOpenaiKey: boolean;
   hasOpenrouterKey: boolean;
   preferredModel: string;
+  tier: string;
 }
 
-export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenrouterKey, preferredModel }: AccountFormProps) {
+export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenrouterKey, preferredModel, tier }: AccountFormProps) {
   const router = useRouter();
   const [name, setName] = useState(displayName);
   const [claudeKey, setClaudeKey] = useState('');
@@ -24,6 +25,19 @@ export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenro
   const [claudeSet, setClaudeSet] = useState(hasClaudeKey);
   const [openaiSet, setOpenaiSet] = useState(hasOpenaiKey);
   const [openrouterSet, setOpenrouterSet] = useState(hasOpenrouterKey);
+  const isProOrAdmin = tier === 'pro' || tier === 'admin';
+  const isFreeNoByok = !isProOrAdmin && !claudeSet && !openaiSet && !openrouterSet;
+
+  let autoOptionLabel = 'Auto (Default routing)';
+  if (claudeSet) {
+    autoOptionLabel = 'Auto (ignored while Claude BYOK key is set)';
+  } else if (openaiSet) {
+    autoOptionLabel = 'Auto (ignored while OpenAI BYOK key is set)';
+  } else if (openrouterSet || isProOrAdmin) {
+    autoOptionLabel = 'Auto (Claude Sonnet 4.6)';
+  } else if (isFreeNoByok) {
+    autoOptionLabel = 'Auto (Nemotron 3 Super 120B - Free default)';
+  }
 
   async function handleSave() {
     setSaving(true);
@@ -130,12 +144,17 @@ export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenro
           onChange={(e) => setModel(e.target.value)}
           className="w-full bg-bg2 border border-border focus:border-amber/50 rounded-[var(--radius-button)] px-4 py-2.5 text-text outline-none font-[family-name:var(--font-mono)] text-sm"
         >
-          <option value="auto">Auto (Claude Sonnet 4.6)</option>
+          <option value="auto">{autoOptionLabel}</option>
           <option value="claude">Claude Sonnet 4.6</option>
           <option value="claude-opus">Claude Opus 4.6</option>
           <option value="gpt">GPT-5.4</option>
           <option value="gpt-codex">GPT-5.3 Codex</option>
         </select>
+        {isFreeNoByok && (
+          <p className="text-text-dim text-xs mt-2">
+            Free tier currently uses the free model pool with default <code className="text-amber">nvidia/nemotron-3-super-120b-a12b:free</code>.
+          </p>
+        )}
       </div>
 
       {/* Claude API Key */}

--- a/web/app/(app)/account/account-form.tsx
+++ b/web/app/(app)/account/account-form.tsx
@@ -33,8 +33,10 @@ export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenro
     autoOptionLabel = 'Auto (ignored while Claude BYOK key is set)';
   } else if (openaiSet) {
     autoOptionLabel = 'Auto (ignored while OpenAI BYOK key is set)';
-  } else if (openrouterSet || isProOrAdmin) {
+  } else if (openrouterSet) {
     autoOptionLabel = 'Auto (Claude Sonnet 4.6)';
+  } else if (isProOrAdmin) {
+    autoOptionLabel = 'Auto (Free model pool default)';
   } else if (isFreeNoByok) {
     autoOptionLabel = 'Auto (Nemotron 3 Super 120B - Free default)';
   }
@@ -153,6 +155,11 @@ export function AccountForm({ displayName, hasClaudeKey, hasOpenaiKey, hasOpenro
         {isFreeNoByok && (
           <p className="text-text-dim text-xs mt-2">
             Free tier currently uses the free model pool with default <code className="text-amber">nvidia/nemotron-3-super-120b-a12b:free</code>.
+          </p>
+        )}
+        {!openrouterSet && isProOrAdmin && (
+          <p className="text-text-dim text-xs mt-2">
+            On {tier.toUpperCase()}, <code className="text-amber">auto</code> uses the free model pool. Pick Claude/GPT explicitly to force frontier models.
           </p>
         )}
       </div>

--- a/web/app/(app)/account/page.tsx
+++ b/web/app/(app)/account/page.tsx
@@ -119,6 +119,7 @@ export default async function AccountPage() {
           hasOpenaiKey={!!profile?.openai_api_key_encrypted}
           hasOpenrouterKey={!!profile?.openrouter_api_key_encrypted}
           preferredModel={profile?.preferred_model || 'auto'}
+          tier={profile?.tier || 'free'}
         />
       </div>
     </div>

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -124,14 +124,15 @@ export async function POST(request: NextRequest) {
     const modelInfo = getModelRoutingInfo(profile);
     const modelConfig = getModelConfig(profile);
     let modelUsed = modelInfo.model;
-    const isFree = profile?.tier !== 'pro' && profile?.tier !== 'admin' && !profile?.claude_api_key_encrypted && !profile?.openai_api_key_encrypted && !profile?.openrouter_api_key_encrypted;
+    const hasByokKeys = !!(profile?.claude_api_key_encrypted || profile?.openai_api_key_encrypted || profile?.openrouter_api_key_encrypted);
+    const useFreeModelPool = modelInfo.model.endsWith(':free') && !hasByokKeys;
 
     // For free tier: pre-fetch relevant data and inject into context (free models don't support tool calling)
     // For pro/BYOK: use tool calling for dynamic data lookup
     let systemPrompt = buildSystemPrompt();
     let content: string;
 
-    if (isFree) {
+    if (useFreeModelPool) {
       const lastUserMsg = messages[messages.length - 1]?.content || '';
 
       // For data-heavy queries, build the response with REAL DATA first,
@@ -197,8 +198,12 @@ Write a brief 2-3 sentence analysis of this data. Focus on: what looks good, wha
         }
 
         if (!responseData || responseData.error) {
+          const isProOrAdmin = profile?.tier === 'pro' || profile?.tier === 'admin';
+          const busyMessage = isProOrAdmin
+            ? 'Your Auto setting is using the free model pool, and those models are busy right now. Try again in a moment, or choose a specific model (Claude/GPT) in Account Settings.'
+            : 'The free AI models are currently busy. Please try again in a moment, or upgrade to Pro: https://github.com/sponsors/MHaggis';
           return new Response(
-            `The free AI models are currently busy. Please try again in a moment, or upgrade to Pro: https://github.com/sponsors/MHaggis`,
+            busyMessage,
             { status: 429 }
           );
         }

--- a/web/lib/ai/router.ts
+++ b/web/lib/ai/router.ts
@@ -101,6 +101,16 @@ export function getModelRoutingInfo(profile: UserProfile | null): ModelRoutingIn
   }
 
   if (profile?.tier === 'pro' || profile?.tier === 'admin') {
+    if (profile.preferred_model === 'auto') {
+      return {
+        source: profile.tier === 'admin' ? 'admin' : 'pro',
+        provider: 'openrouter',
+        model: FREE_MODEL,
+        modelLabel: getModelLabel(FREE_MODEL),
+        note: 'Auto uses the free model pool by default. Pick Claude/GPT explicitly to use frontier models.',
+        fallbackModels: FREE_MODELS,
+      };
+    }
     const model = PRO_MODELS[profile.preferred_model] || PRO_MODELS['auto'];
     return {
       source: profile.tier === 'admin' ? 'admin' : 'pro',


### PR DESCRIPTION
## Summary
- fix misleading `Preferred Model -> Auto` label in account settings for free-tier users
- show `Auto (Nemotron 3 Super 120B - Free default)` when account is free and no BYOK keys are set
- make auto label context-aware for BYOK and Pro/Admin states so it doesn't imply Sonnet/Opus when not in use
- add a short helper line under the selector on free tier clarifying the actual default free model pool behavior

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run lint`
