### PR TITLE
feat(sources): add Jamf Protect custom analytic detections as new source

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -50,6 +50,10 @@ jobs:
           # CrowdStrike CQL Hub
           git clone --depth 1 https://github.com/ByteRay-Labs/Query-Hub.git /tmp/repos/cql-hub
 
+          # Jamf Protect custom analytic detections (macOS)
+          git clone --depth 1 --filter=blob:none --sparse https://github.com/jamf/jamfprotect.git /tmp/repos/jamfprotect
+          cd /tmp/repos/jamfprotect && git sparse-checkout set custom_analytic_detections && cd -
+
           # MITRE ATT&CK STIX data
           git clone --depth 1 https://github.com/mitre-attack/attack-stix-data.git /tmp/repos/stix
 
@@ -66,6 +70,7 @@ jobs:
           KQL_PATHS: /tmp/repos/kql-bertjanp,/tmp/repos/kql-jkerai1
           SUBLIME_PATHS: /tmp/repos/sublime/detection-rules
           CQL_HUB_PATHS: /tmp/repos/cql-hub/queries
+          JAMF_PROTECT_PATHS: /tmp/repos/jamfprotect/custom_analytic_detections
           ATTACK_STIX_PATH: /tmp/repos/stix/enterprise-attack/enterprise-attack.json
 
       - name: Wait for MCP server to finish indexing

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Configure env vars to point at your detection repos:
 | `KQL_PATHS` | KQL hunting query directories |
 | `SUBLIME_PATHS` | Sublime Security rule directories |
 | `CQL_HUB_PATHS` | CQL Hub (CrowdStrike) query directories |
+| `JAMF_PROTECT_PATHS` | Jamf Protect custom analytic detection directories (macOS) |
 | `STORY_PATHS` | Splunk analytic story directories (optional) |
 | `ATTACK_STIX_PATH` | Path to `enterprise-attack.json` for threat actor data (optional) |
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ git clone --depth 1 https://github.com/ByteRay-Labs/Query-Hub.git cql-hub
 | `search(query, limit)` | Full-text search across all detection fields |
 | `get_by_id(id)` | Get a single detection by ID |
 | `list_all(limit, offset)` | Paginated list of all detections |
-| `list_by_source(source_type)` | Filter by source (`sigma`, `splunk_escu`, `elastic`, `kql`, `sublime`, `crowdstrike_cql`) |
+| `list_by_source(source_type)` | Filter by source (`sigma`, `splunk_escu`, `elastic`, `kql`, `sublime`, `crowdstrike_cql`, `jamf_protect`) |
 | `get_stats()` | Index statistics |
 | `rebuild_index()` | Force re-index from configured paths |
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -172,6 +172,7 @@ Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
         "STORY_PATHS": "/absolute/path/to/detections/security_content/stories",
         "SUBLIME_PATHS": "/absolute/path/to/detections/sublime-rules/detection-rules",
         "CQL_HUB_PATHS": "/absolute/path/to/detections/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/absolute/path/to/detections/jamfprotect/custom_analytic_detections",
         "ATTACK_STIX_PATH": "/absolute/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json"
       }
     }
@@ -200,6 +201,7 @@ Add to `~/.vscode/mcp.json`:
         "STORY_PATHS": "/absolute/path/to/detections/security_content/stories",
         "SUBLIME_PATHS": "/absolute/path/to/detections/sublime-rules/detection-rules",
         "CQL_HUB_PATHS": "/absolute/path/to/detections/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/absolute/path/to/detections/jamfprotect/custom_analytic_detections",
         "ATTACK_STIX_PATH": "/absolute/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json"
       }
     }
@@ -225,7 +227,8 @@ If you're running VS Code on Windows but your files are inside WSL:
         "KQL_PATHS": "/home/youruser/detections/kql-bertjanp",
         "STORY_PATHS": "/home/youruser/detections/security_content/stories",
         "SUBLIME_PATHS": "/home/youruser/detections/sublime-rules/detection-rules",
-        "CQL_HUB_PATHS": "/home/youruser/detections/cql-hub/queries"
+        "CQL_HUB_PATHS": "/home/youruser/detections/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/home/youruser/detections/jamfprotect/custom_analytic_detections"
       }
     }
   }
@@ -249,6 +252,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
         "SPLUNK_PATHS": "/absolute/path/to/detections/security_content/detections",
         "SUBLIME_PATHS": "/absolute/path/to/detections/sublime-rules/detection-rules",
         "CQL_HUB_PATHS": "/absolute/path/to/detections/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/absolute/path/to/detections/jamfprotect/custom_analytic_detections",
         "ATTACK_STIX_PATH": "/absolute/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json"
       }
     }

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsc --watch",
-    "test": "npm run build && node tests/cross-platform-test.js && node tests/integration-test.js && node tests/engineering-tools-test.js",
+    "test": "npm run build && node tests/cross-platform-test.js && node tests/jamf-parser-test.js && node tests/integration-test.js && node tests/engineering-tools-test.js",
     "test:platform": "npm run build && node tests/cross-platform-test.js",
     "test:ci": "npm run build && node tests/ci-integration-test.js",
     "test:integration": "npm run build && node tests/integration-test.js",
     "test:engineering": "npm run build && node tests/engineering-tools-test.js",
+    "test:jamf": "npm run build && node tests/jamf-parser-test.js",
     "lint": "tsc --noEmit --strict",
     "prepublishOnly": "npm run build && npm run lint"
   },
@@ -43,6 +44,8 @@
     "sublime",
     "crowdstrike",
     "cql",
+    "jamf",
+    "macos",
     "siem",
     "mitre",
     "attack"

--- a/server.json
+++ b/server.json
@@ -36,6 +36,18 @@
           "description": "Comma-separated paths to KQL hunting query directories (e.g., /path/to/kql-queries)"
         },
         {
+          "name": "SUBLIME_PATHS",
+          "description": "Comma-separated paths to Sublime Security rule directories (e.g., /path/to/sublime-rules/detection-rules)"
+        },
+        {
+          "name": "CQL_HUB_PATHS",
+          "description": "Comma-separated paths to CQL Hub (CrowdStrike) query directories (e.g., /path/to/cql-hub/queries)"
+        },
+        {
+          "name": "JAMF_PROTECT_PATHS",
+          "description": "Comma-separated paths to Jamf Protect custom analytic detection directories (macOS, e.g., /path/to/jamfprotect/custom_analytic_detections)"
+        },
+        {
           "name": "STORY_PATHS",
           "description": "Comma-separated paths to Splunk analytic story directories (optional, e.g., /path/to/security_content/stories)"
         }

--- a/src/db.ts
+++ b/src/db.ts
@@ -285,7 +285,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
     mitre_ids: JSON.parse(row.mitre_ids as string || '[]'),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -354,7 +354,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
   return rows.map(rowToDetection);
 }
 
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect', limit: number = 100, offset: number = 0): Detection[] {
   const database = initDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -1366,7 +1366,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
 
 // Get name+ID list filtered by source
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1460,7 +1460,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
 // Get detection names and IDs matching a pattern, grouped by source
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = initDb();
   

--- a/src/db.ts
+++ b/src/db.ts
@@ -553,6 +553,8 @@ export function getStats(): IndexStats {
   const elastic = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'elastic'").get() as { count: number }).count;
   const kql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'kql'").get() as { count: number }).count;
   const sublime = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'sublime'").get() as { count: number }).count;
+  const crowdstrikeCql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'crowdstrike_cql'").get() as { count: number }).count;
+  const jamfProtect = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'jamf_protect'").get() as { count: number }).count;
 
   // Count by severity
   const severityRows = database.prepare(`
@@ -644,6 +646,8 @@ export function getStats(): IndexStats {
     elastic,
     kql,
     sublime,
+    crowdstrike_cql: crowdstrikeCql,
+    jamf_protect: jamfProtect,
     by_severity,
     by_logsource_product,
     mitre_coverage,
@@ -1503,7 +1507,15 @@ export function countDetectionsBySource(topic: string): Record<string, number> {
   
   const rows = stmt.all(topic) as { source_type: string; count: number }[];
   
-  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0 };
+  const result: Record<string, number> = {
+    sigma: 0,
+    splunk_escu: 0,
+    elastic: 0,
+    kql: 0,
+    sublime: 0,
+    crowdstrike_cql: 0,
+    jamf_protect: 0,
+  };
   for (const row of rows) {
     result[row.source_type] = row.count;
   }

--- a/src/db/detections.ts
+++ b/src/db/detections.ts
@@ -21,7 +21,7 @@ export interface ValidationResult {
 }
 
 export interface TechniqueIdFilters {
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
   tactic?: string;
   severity?: string;
 }
@@ -54,7 +54,7 @@ export interface DetectionSuggestion {
 export interface NavigatorLayerOptions {
   name: string;
   description?: string;
-  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+  source_type?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
   tactic?: string;
   severity?: string;
   actor_name?: string;
@@ -122,7 +122,7 @@ function rowToDetection(row: Record<string, unknown>): Detection {
     name: row.name as string,
     description: row.description as string || '',
     query: row.query as string || '',
-    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
+    source_type: row.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
     mitre_ids: safeJsonParse<string[]>(row.mitre_ids as string, []),
     logsource_category: row.logsource_category as string | null,
     logsource_product: row.logsource_product as string | null,
@@ -297,7 +297,7 @@ export function listDetections(limit: number = 100, offset: number = 0): Detecti
 /**
  * List detections filtered by source type.
  */
-export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql', limit: number = 100, offset: number = 0): Detection[] {
+export function listBySource(sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect', limit: number = 100, offset: number = 0): Detection[] {
   const database = getDb();
   
   const stmt = database.prepare('SELECT * FROM detections WHERE source_type = ? ORDER BY name LIMIT ? OFFSET ?');
@@ -832,7 +832,7 @@ export function getTechniqueIds(filters: TechniqueIdFilters = {}): string[] {
 /**
  * Analyze coverage by tactic and identify strengths/weaknesses.
  */
-export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'): CoverageReport {
+export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect'): CoverageReport {
   const database = getDb();
   
   let countSql = 'SELECT COUNT(DISTINCT id) as count FROM detections';
@@ -943,7 +943,7 @@ export function analyzeCoverage(sourceType?: 'sigma' | 'splunk_escu' | 'elastic'
  */
 export function identifyGaps(
   threatProfile: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect'
 ): GapAnalysis {
   const targetTechniques = THREAT_PROFILES[threatProfile.toLowerCase()] || THREAT_PROFILES['apt'];
   
@@ -999,7 +999,7 @@ export function identifyGaps(
  */
 export function suggestDetections(
   techniqueId: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect'
 ): DetectionSuggestion {
   const database = getDb();
   
@@ -1469,7 +1469,7 @@ export function searchDetectionList(query: string, limit: number = 500): Detecti
  * List detections by source with optional name filter, returning lightweight results.
  */
 export function listDetectionsBySourceLight(
-  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
+  sourceType: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
   nameFilter?: string,
   limit: number = 500
 ): DetectionListItem[] {
@@ -1562,7 +1562,7 @@ export function compareDetectionsBySource(topic: string, limit: number = 100): S
  */
 export function getDetectionNamesByPattern(
   pattern: string,
-  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql'
+  sourceType?: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect'
 ): { source: string; detections: Array<{ name: string; id: string }> }[] {
   const database = getDb();
   

--- a/src/db/detections.ts
+++ b/src/db/detections.ts
@@ -554,6 +554,8 @@ export function getStats(): IndexStats {
   const elastic = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'elastic'").get() as { count: number }).count;
   const kql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'kql'").get() as { count: number }).count;
   const sublime = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'sublime'").get() as { count: number }).count;
+  const crowdstrikeCql = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'crowdstrike_cql'").get() as { count: number }).count;
+  const jamfProtect = (database.prepare("SELECT COUNT(*) as count FROM detections WHERE source_type = 'jamf_protect'").get() as { count: number }).count;
 
   // Count by severity
   const severityRows = database.prepare(`
@@ -645,6 +647,8 @@ export function getStats(): IndexStats {
     elastic,
     kql,
     sublime,
+    crowdstrike_cql: crowdstrikeCql,
+    jamf_protect: jamfProtect,
     by_severity,
     by_logsource_product,
     mitre_coverage,
@@ -1606,7 +1610,15 @@ export function countDetectionsBySource(topic: string): Record<string, number> {
   
   const rows = stmt.all(topic) as { source_type: string; count: number }[];
   
-  const result: Record<string, number> = { sigma: 0, splunk_escu: 0, elastic: 0, kql: 0, sublime: 0, crowdstrike_cql: 0 };
+  const result: Record<string, number> = {
+    sigma: 0,
+    splunk_escu: 0,
+    elastic: 0,
+    kql: 0,
+    sublime: 0,
+    crowdstrike_cql: 0,
+    jamf_protect: 0,
+  };
   for (const row of rows) {
     result[row.source_type] = row.count;
   }

--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -13,6 +13,21 @@ import {
   getKnowledgeStats,
 } from '../db/knowledge.js';
 
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] as const;
+type SourceType = (typeof SOURCE_TYPES)[number];
+
+function countBySource(detections: Array<{ source_type: string }>): Record<SourceType, number> {
+  const counts = Object.fromEntries(SOURCE_TYPES.map(source => [source, 0])) as Record<SourceType, number>;
+
+  for (const detection of detections) {
+    if ((SOURCE_TYPES as readonly string[]).includes(detection.source_type)) {
+      counts[detection.source_type as SourceType]++;
+    }
+  }
+
+  return counts;
+}
+
 // =============================================================================
 // TYPE DEFINITIONS
 // =============================================================================
@@ -70,7 +85,7 @@ export const resources: ResourceDefinition[] = [
   {
     uri: 'detection://sources/comparison',
     name: 'Source Comparison',
-    description: 'Quick comparison of detection counts across sources (sigma, splunk, elastic, kql)',
+    description: 'Quick comparison of detection counts across all sources',
     mimeType: 'application/json',
   },
   // Knowledge graph resources
@@ -151,12 +166,7 @@ function getTechniqueResource(techniqueId: string): unknown {
       severity: d.severity,
       description: d.description?.substring(0, 200) + (d.description && d.description.length > 200 ? '...' : ''),
     })),
-    by_source: {
-      sigma: detections.filter(d => d.source_type === 'sigma').length,
-      splunk_escu: detections.filter(d => d.source_type === 'splunk_escu').length,
-      elastic: detections.filter(d => d.source_type === 'elastic').length,
-      kql: detections.filter(d => d.source_type === 'kql').length,
-    },
+    by_source: countBySource(detections),
   };
 }
 
@@ -284,12 +294,7 @@ function getStaticResourceContent(uri: string): unknown {
       const stats = getStats();
       return {
         total_detections: stats.total,
-        by_source: {
-          sigma: stats.sigma,
-          splunk_escu: stats.splunk_escu,
-          elastic: stats.elastic,
-          kql: stats.kql,
-        },
+        by_source: Object.fromEntries(SOURCE_TYPES.map(source => [source, stats[source]])),
         by_severity: stats.by_severity,
         mitre_coverage: stats.mitre_coverage,
         by_mitre_tactic: stats.by_mitre_tactic,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,21 +32,22 @@ const STORY_PATHS = parsePaths(process.env.STORY_PATHS);
 const KQL_PATHS = parsePaths(process.env.KQL_PATHS);
 const SUBLIME_PATHS = parsePaths(process.env.SUBLIME_PATHS);
 const CQL_HUB_PATHS = parsePaths(process.env.CQL_HUB_PATHS);
+const JAMF_PROTECT_PATHS = parsePaths(process.env.JAMF_PROTECT_PATHS);
 const ATTACK_STIX_PATH = process.env.ATTACK_STIX_PATH;
 
 // Auto-index on startup if paths are configured and DB is empty
 function autoIndex(): void {
-  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0 && CQL_HUB_PATHS.length === 0) {
+  if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0 && CQL_HUB_PATHS.length === 0 && JAMF_PROTECT_PATHS.length === 0) {
     return;
   }
-  
+
   initDb();
-  
+
   if (needsIndexing()) {
     console.error('[security-detections-mcp] Auto-indexing detections...');
-    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS, CQL_HUB_PATHS);
+    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS, CQL_HUB_PATHS, JAMF_PROTECT_PATHS);
     let msg = `[security-detections-mcp] Indexed ${result.total} detections`;
-    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL, ${result.sublime_indexed} Sublime, ${result.cql_hub_indexed} CrowdStrike CQL)`;
+    msg += ` (${result.sigma_indexed} Sigma, ${result.splunk_indexed} Splunk, ${result.elastic_indexed} Elastic, ${result.kql_indexed} KQL, ${result.sublime_indexed} Sublime, ${result.cql_hub_indexed} CrowdStrike CQL, ${result.jamf_protect_indexed} Jamf Protect)`;
     if (result.stories_indexed > 0) {
       msg += `, ${result.stories_indexed} stories`;
     }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -7,6 +7,7 @@ import { parseElasticFile } from './parsers/elastic.js';
 import { parseKqlFile, parseRawKqlFile } from './parsers/kql.js';
 import { parseSublimeFile } from './parsers/sublime.js';
 import { parseCqlHubFile } from './parsers/crowdstrike_cql.js';
+import { parseJamfProtectFile } from './parsers/jamf_protect.js';
 import { recreateDb, insertDetection, insertStory, getDetectionCount, initDb } from './db.js';
 
 // Recursively find all YAML files in a directory
@@ -139,6 +140,8 @@ export interface IndexResult {
   sublime_failed: number;
   cql_hub_indexed: number;
   cql_hub_failed: number;
+  jamf_protect_indexed: number;
+  jamf_protect_failed: number;
   stories_indexed: number;
   stories_failed: number;
   total: number;
@@ -151,7 +154,8 @@ export function indexDetections(
   elasticPaths: string[] = [],
   kqlPaths: string[] = [],
   sublimePaths: string[] = [],
-  cqlHubPaths: string[] = []
+  cqlHubPaths: string[] = [],
+  jamfProtectPaths: string[] = []
 ): IndexResult {
   // Recreate DB to ensure schema is up to date
   recreateDb();
@@ -169,6 +173,8 @@ export function indexDetections(
   let sublime_failed = 0;
   let cql_hub_indexed = 0;
   let cql_hub_failed = 0;
+  let jamf_protect_indexed = 0;
+  let jamf_protect_failed = 0;
   let stories_indexed = 0;
   let stories_failed = 0;
   
@@ -274,6 +280,21 @@ export function indexDetections(
     }
   }
 
+  // Index Jamf Protect custom analytic detections (YAML with NSPredicate filter)
+  for (const basePath of jamfProtectPaths) {
+    const files = findYamlFiles(basePath);
+
+    for (const file of files) {
+      const detection = parseJamfProtectFile(file);
+      if (detection) {
+        insertDetection(detection);
+        jamf_protect_indexed++;
+      } else {
+        jamf_protect_failed++;
+      }
+    }
+  }
+
   // Index Splunk Analytic Stories (optional)
   for (const basePath of storyPaths) {
     const files = findYamlFiles(basePath);
@@ -302,9 +323,11 @@ export function indexDetections(
     sublime_failed,
     cql_hub_indexed,
     cql_hub_failed,
+    jamf_protect_indexed,
+    jamf_protect_failed,
     stories_indexed,
     stories_failed,
-    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed + sublime_indexed + cql_hub_indexed,
+    total: sigma_indexed + splunk_indexed + elastic_indexed + kql_indexed + sublime_indexed + cql_hub_indexed + jamf_protect_indexed,
   };
 }
 

--- a/src/parsers/jamf_protect.ts
+++ b/src/parsers/jamf_protect.ts
@@ -1,0 +1,243 @@
+import { readFileSync } from 'fs';
+import { parse as parseYaml } from 'yaml';
+import { createHash } from 'crypto';
+import type { Detection, JamfProtectRule } from '../types.js';
+
+// MITRE tactic normalization: Jamf's `MitreCategories` mixes CamelCase (`CredentialAccess`),
+// spaced (`Credential Access`), and Jamf-specific labels (`LivingOffTheLand`). Normalize the
+// input by lowercasing and stripping whitespace, then map to MITRE tactic kebab-case.
+const TACTIC_MAP: Record<string, string> = {
+  reconnaissance: 'reconnaissance',
+  resourcedevelopment: 'resource-development',
+  initialaccess: 'initial-access',
+  execution: 'execution',
+  persistence: 'persistence',
+  privilegeescalation: 'privilege-escalation',
+  defenseevasion: 'defense-evasion',
+  credentialaccess: 'credential-access',
+  discovery: 'discovery',
+  lateralmovement: 'lateral-movement',
+  collection: 'collection',
+  commandandcontrol: 'command-and-control',
+  exfiltration: 'exfiltration',
+  impact: 'impact',
+};
+
+// Best-effort mapping for Jamf-specific labels → MITRE techniques + tactics.
+// Claims are approximate and lossy but give the coverage-analysis tooling something to work with.
+const JAMF_LABEL_MAP: Record<string, { techniques: string[]; tactics: string[] }> = {
+  livingofftheland: {
+    techniques: ['T1059', 'T1218'],
+    tactics: ['execution', 'defense-evasion'],
+  },
+  knownmalware: {
+    techniques: ['T1204.002'],
+    tactics: ['execution'],
+  },
+  knownmaliciousfile: {
+    techniques: ['T1204.002'],
+    tactics: ['execution'],
+  },
+  adversaryinthemiddle: {
+    techniques: ['T1557'],
+    tactics: ['credential-access'],
+  },
+  credentialharvesting: {
+    techniques: ['T1555'],
+    tactics: ['credential-access'],
+  },
+  exploitation: {
+    techniques: ['T1203', 'T1068'],
+    tactics: ['execution', 'privilege-escalation'],
+  },
+  systemtampering: {
+    techniques: ['T1565'],
+    tactics: ['impact'],
+  },
+  visibility: {
+    techniques: [],
+    tactics: ['discovery'],
+  },
+  systemvisibility: {
+    techniques: [],
+    tactics: ['discovery'],
+  },
+};
+
+const TECHNIQUE_ID_RE = /^t(\d{4}(?:\.\d{3})?)$/;
+
+interface MitreExtraction {
+  ids: string[];
+  tactics: string[];
+  rawLabels: string[];
+}
+
+function extractMitre(raw: string[] | null | undefined): MitreExtraction {
+  const ids = new Set<string>();
+  const tactics = new Set<string>();
+  const rawLabels: string[] = [];
+  if (!raw) return { ids: [], tactics: [], rawLabels: [] };
+
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue;
+    rawLabels.push(entry);
+    const normalized = entry.toLowerCase().replace(/[\s_-]/g, '');
+
+    const techMatch = normalized.match(TECHNIQUE_ID_RE);
+    if (techMatch) {
+      ids.add(`T${techMatch[1].toUpperCase()}`);
+      continue;
+    }
+
+    if (TACTIC_MAP[normalized]) {
+      tactics.add(TACTIC_MAP[normalized]);
+      continue;
+    }
+
+    const labelMapping = JAMF_LABEL_MAP[normalized];
+    if (labelMapping) {
+      labelMapping.techniques.forEach(t => ids.add(t));
+      labelMapping.tactics.forEach(t => tactics.add(t));
+    }
+  }
+
+  return { ids: [...ids], tactics: [...tactics], rawLabels };
+}
+
+function extractDataSources(inputType: string | undefined): string[] {
+  const base = 'macOS Endpoint Security';
+  switch (inputType) {
+    case 'GPProcessEvent':
+      return ['Process Events', base];
+    case 'GPFSEvent':
+      return ['File System Events', base];
+    case 'GPKeylogRegisterEvent':
+      return ['Keylog Register Events', base];
+    case 'GPUSBEvent':
+      return ['USB Events', base];
+    default:
+      return inputType ? [inputType, base] : [base];
+  }
+}
+
+// Pull process names from NSPredicate filter text.
+// Jamf filters reference processes via `path.lastPathComponent == "<name>"` or
+// `signingInfo.appid == "com.apple.<name>"`.
+function extractProcessNames(filter: string): string[] {
+  const names = new Set<string>();
+
+  const lastComponentRe = /lastPathComponent\s*==\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = lastComponentRe.exec(filter)) !== null) {
+    if (m[1]) names.add(m[1]);
+  }
+
+  const appidRe = /signingInfo\.appid\s*==\s*"com\.apple\.([A-Za-z0-9_.-]+)"/gi;
+  while ((m = appidRe.exec(filter)) !== null) {
+    if (m[1]) names.add(m[1]);
+  }
+
+  return [...names];
+}
+
+// Pull quoted absolute-path references from NSPredicate filter text.
+function extractFilePaths(filter: string): string[] {
+  const paths = new Set<string>();
+  const re = /"(\/[^"\s]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(filter)) !== null) {
+    const candidate = m[1];
+    if (candidate.length < 3) continue;
+    // Skip bundle identifiers and uri-ish schemes.
+    if (!candidate.startsWith('/')) continue;
+    paths.add(candidate);
+  }
+  return [...paths];
+}
+
+function normalizeSeverity(severity: string | undefined): string | null {
+  if (!severity) return null;
+  return severity.toLowerCase();
+}
+
+function generateId(filePath: string, name: string, uuid: string | undefined): string {
+  // Upstream Jamf content occasionally reuses the same uuid across different files
+  // (e.g. openclaw_directory_created vs openclaw_onboard both declare the same uuid).
+  // Incorporate the filename into the hash so each file produces a unique id; keep
+  // the uuid as a prefix when available so it's still recognizable.
+  const basename = filePath.split('/').pop() || filePath;
+  const hash = createHash('sha256').update(`${filePath}:${name}`).digest('hex').substring(0, 12);
+  if (uuid) {
+    return `jamf-${uuid}-${hash}`;
+  }
+  return `jamf-${createHash('sha256').update(`${basename}:${name}`).digest('hex').substring(0, 32)}`;
+}
+
+export function parseJamfProtectFile(filePath: string): Detection | null {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const rule = parseYaml(content) as JamfProtectRule | null;
+
+    if (!rule || typeof rule !== 'object') return null;
+    if (!rule.name || !rule.filter) return null;
+
+    const mitre = extractMitre(rule.MitreCategories ?? null);
+
+    const baseTags: string[] = Array.isArray(rule.tags)
+      ? (rule.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+      : [];
+    const categoryTags: string[] = Array.isArray(rule.categories)
+      ? (rule.categories as unknown[]).filter((t): t is string => typeof t === 'string')
+      : [];
+    // Preserve the raw Jamf MITRE labels so their original semantics stay searchable.
+    const tags = [...new Set([...baseTags, ...categoryTags, ...mitre.rawLabels])];
+
+    const description = rule.longDescription || rule.shortDescription || '';
+    const id = generateId(filePath, rule.name, rule.uuid);
+
+    const detection: Detection = {
+      id,
+      name: rule.label || rule.name,
+      description,
+      query: rule.filter,
+      source_type: 'jamf_protect',
+      mitre_ids: mitre.ids,
+      logsource_category: rule.inputType || null,
+      logsource_product: 'macos',
+      logsource_service: 'jamf_protect',
+      severity: normalizeSeverity(rule.severity),
+      status: null,
+      author: 'Jamf',
+      date_created: null,
+      date_modified: null,
+      references: [],
+      falsepositives: [],
+      tags,
+      file_path: filePath,
+      raw_yaml: content,
+
+      cves: [],
+      analytic_stories: [],
+      data_sources: extractDataSources(rule.inputType),
+      detection_type: 'TTP',
+      asset_type: 'Endpoint',
+      security_domain: 'endpoint',
+      process_names: extractProcessNames(rule.filter),
+      file_paths: extractFilePaths(rule.filter),
+      registry_paths: [],
+      mitre_tactics: mitre.tactics,
+      platforms: ['macos'],
+      kql_category: null,
+      kql_tags: [],
+      kql_keywords: [],
+
+      sublime_attack_types: [],
+      sublime_detection_methods: [],
+      sublime_tactics: [],
+    };
+
+    return detection;
+  } catch {
+    return null;
+  }
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -256,7 +256,7 @@ function getTacticResource(tactic: string): unknown {
  * Get statistics and sample detections for a source type
  */
 function getSourceResource(sourceType: string): unknown {
-  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'];
+  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'];
   const normalizedSource = sourceType.toLowerCase();
 
   if (!validSources.includes(normalizedSource)) {
@@ -267,7 +267,7 @@ function getSourceResource(sourceType: string): unknown {
   }
 
   const detections = listBySource(
-    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql',
+    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
     50
   );
 
@@ -582,7 +582,7 @@ export async function readResource(uri: string) {
   // Navigator layer template: detection://navigator/layer/{sourceType}
   const navigatorMatch = uri.match(/^detection:\/\/navigator\/layer\/(.+)$/);
   if (navigatorMatch) {
-    const sourceType = decodeURIComponent(navigatorMatch[1]) as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+    const sourceType = decodeURIComponent(navigatorMatch[1]) as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
     content = generateNavigatorLayer({ name: `${sourceType} Detection Coverage`, source_type: sourceType });
     return formatResourceResponse(uri, mimeType, content);
   }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -31,6 +31,21 @@ import {
   getKnowledgeStats,
 } from '../db/knowledge.js';
 
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] as const;
+type SourceType = (typeof SOURCE_TYPES)[number];
+
+function countBySource(detections: Array<{ source_type: string }>): Record<SourceType, number> {
+  const counts = Object.fromEntries(SOURCE_TYPES.map((source) => [source, 0])) as Record<SourceType, number>;
+
+  for (const detection of detections) {
+    if ((SOURCE_TYPES as readonly string[]).includes(detection.source_type)) {
+      counts[detection.source_type as SourceType]++;
+    }
+  }
+
+  return counts;
+}
+
 // =============================================================================
 // TYPE DEFINITIONS
 // =============================================================================
@@ -88,7 +103,7 @@ export const resources: ResourceDefinition[] = [
   {
     uri: 'detection://sources/comparison',
     name: 'Source Comparison',
-    description: 'Quick comparison of detection counts across sources (sigma, splunk, elastic, kql)',
+    description: 'Quick comparison of detection counts across all sources',
     mimeType: 'application/json',
   },
   // Navigator layer
@@ -139,7 +154,7 @@ export const resourceTemplates: ResourceTemplateDefinition[] = [
   {
     uriTemplate: 'detection://source/{sourceType}',
     name: 'Source Statistics',
-    description: 'Get statistics and detections for a specific source type (sigma, splunk_escu, elastic, kql)',
+    description: 'Get statistics and detections for a specific source type',
     mimeType: 'application/json',
   },
   {
@@ -157,7 +172,7 @@ export const resourceTemplates: ResourceTemplateDefinition[] = [
   {
     uriTemplate: 'detection://navigator/layer/{sourceType}',
     name: 'Source-Filtered Navigator Layer',
-    description: 'ATT&CK Navigator layer filtered by detection source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql)',
+    description: 'ATT&CK Navigator layer filtered by detection source',
     mimeType: 'application/json',
   },
   {
@@ -202,12 +217,7 @@ function getTechniqueResource(techniqueId: string): unknown {
         d.description?.substring(0, 200) +
         (d.description && d.description.length > 200 ? '...' : ''),
     })),
-    by_source: {
-      sigma: detections.filter((d) => d.source_type === 'sigma').length,
-      splunk_escu: detections.filter((d) => d.source_type === 'splunk_escu').length,
-      elastic: detections.filter((d) => d.source_type === 'elastic').length,
-      kql: detections.filter((d) => d.source_type === 'kql').length,
-    },
+    by_source: countBySource(detections),
   };
 }
 
@@ -243,12 +253,7 @@ function getTacticResource(tactic: string): unknown {
       severity: d.severity,
       mitre_ids: d.mitre_ids,
     })),
-    by_source: {
-      sigma: detections.filter((d) => d.source_type === 'sigma').length,
-      splunk_escu: detections.filter((d) => d.source_type === 'splunk_escu').length,
-      elastic: detections.filter((d) => d.source_type === 'elastic').length,
-      kql: detections.filter((d) => d.source_type === 'kql').length,
-    },
+    by_source: countBySource(detections),
   };
 }
 
@@ -256,10 +261,10 @@ function getTacticResource(tactic: string): unknown {
  * Get statistics and sample detections for a source type
  */
 function getSourceResource(sourceType: string): unknown {
-  const validSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'];
+  const validSources = [...SOURCE_TYPES];
   const normalizedSource = sourceType.toLowerCase();
 
-  if (!validSources.includes(normalizedSource)) {
+  if (!(validSources as readonly string[]).includes(normalizedSource)) {
     return {
       error: `Invalid source type: ${sourceType}`,
       valid_sources: validSources,
@@ -267,7 +272,7 @@ function getSourceResource(sourceType: string): unknown {
   }
 
   const detections = listBySource(
-    normalizedSource as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect',
+    normalizedSource as SourceType,
     50
   );
 
@@ -471,12 +476,7 @@ function getStaticResourceContent(uri: string): unknown {
       const stats = getStats();
       return {
         total_detections: stats.total,
-        by_source: {
-          sigma: stats.sigma,
-          splunk_escu: stats.splunk_escu,
-          elastic: stats.elastic,
-          kql: stats.kql,
-        },
+        by_source: Object.fromEntries(SOURCE_TYPES.map((source) => [source, stats[source]])),
         by_severity: stats.by_severity,
         mitre_coverage: stats.mitre_coverage,
         by_mitre_tactic: stats.by_mitre_tactic,

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,7 +169,7 @@ export function createServer(): Server {
         break;
       case 'source_type':
       case 'source':
-        values = ['sigma', 'splunk_escu', 'elastic', 'kql'].filter(s => 
+        values = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'].filter(s =>
           s.toLowerCase().startsWith(prefix.toLowerCase())
         );
         break;

--- a/src/tools/autonomous/index.ts
+++ b/src/tools/autonomous/index.ts
@@ -46,6 +46,8 @@ import { requestAnalysis, getSamplingStatus } from '../../handlers/sampling.js';
 // Helper Functions
 // ============================================================================
 
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] as const;
+
 /**
  * Format current timestamp for storage
  */
@@ -276,7 +278,7 @@ Use this for executive-level reporting on detection posture.`,
       const highPriorityTechniques = ['T1059.001', 'T1003.001', 'T1547.001', 'T1486', 'T1078'];
       const sourceStats: Record<string, number> = {};
 
-      for (const source of ['sigma', 'splunk_escu', 'elastic', 'kql'] as const) {
+      for (const source of SOURCE_TYPES) {
         const detections = listBySource(source, 9999);
         sourceStats[source] = detections.length;
       }
@@ -451,7 +453,7 @@ Use this to understand the strengths/weaknesses of different detection sources a
 
     ensureDynamicSchema();
 
-    const sources = ['sigma', 'splunk_escu', 'elastic', 'kql'] as const;
+    const sources = SOURCE_TYPES;
     
     // Get overall stats by source
     const sourceStats: Record<string, { total: number; coverage: CoverageReport }> = {};

--- a/src/tools/cache/index.ts
+++ b/src/tools/cache/index.ts
@@ -27,6 +27,9 @@ const SPLUNK_PATHS = parsePaths(process.env.SPLUNK_PATHS);
 const ELASTIC_PATHS = parsePaths(process.env.ELASTIC_PATHS);
 const STORY_PATHS = parsePaths(process.env.STORY_PATHS);
 const KQL_PATHS = parsePaths(process.env.KQL_PATHS);
+const SUBLIME_PATHS = parsePaths(process.env.SUBLIME_PATHS);
+const CQL_HUB_PATHS = parsePaths(process.env.CQL_HUB_PATHS);
+const JAMF_PROTECT_PATHS = parsePaths(process.env.JAMF_PROTECT_PATHS);
 
 // =============================================================================
 // Saved Query Tools
@@ -179,10 +182,10 @@ const rebuildIndexTool = defineTool({
     const confirmArg = args?.confirm as boolean;
     const skipElicitation = args?.skip_elicitation as boolean;
     
-    if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0) {
+    if (SIGMA_PATHS.length === 0 && SPLUNK_PATHS.length === 0 && ELASTIC_PATHS.length === 0 && KQL_PATHS.length === 0 && SUBLIME_PATHS.length === 0 && CQL_HUB_PATHS.length === 0 && JAMF_PROTECT_PATHS.length === 0) {
       return {
         error: true,
-        message: 'No paths configured. Set SIGMA_PATHS, SPLUNK_PATHS, ELASTIC_PATHS, and/or KQL_PATHS environment variables.',
+        message: 'No paths configured. Set SIGMA_PATHS, SPLUNK_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS, CQL_HUB_PATHS, and/or JAMF_PROTECT_PATHS environment variables.',
       };
     }
 
@@ -257,7 +260,7 @@ const rebuildIndexTool = defineTool({
     // Recreate DB to apply schema changes
     recreateDb();
 
-    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS);
+    const result = indexDetections(SIGMA_PATHS, SPLUNK_PATHS, STORY_PATHS, ELASTIC_PATHS, KQL_PATHS, SUBLIME_PATHS, CQL_HUB_PATHS, JAMF_PROTECT_PATHS);
     
     // Notify subscribers that resources have changed
     try {

--- a/src/tools/detections/actor-analysis.ts
+++ b/src/tools/detections/actor-analysis.ts
@@ -17,7 +17,7 @@ import {
   generateNavigatorLayer,
 } from '../../db/index.js';
 
-const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'] as const;
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] as const;
 
 function stixNotLoadedError() {
   return {

--- a/src/tools/detections/analysis.ts
+++ b/src/tools/detections/analysis.ts
@@ -37,7 +37,7 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter by source type',
         },
         tactic: {
@@ -58,7 +58,7 @@ export const analysisTools = [
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
       const tactic = args.tactic as string | undefined;
       const severity = args.severity as string | undefined;
 
@@ -83,13 +83,13 @@ export const analysisTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter by source type (optional - analyzes all if not specified)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
       const report = analyzeCoverage(sourceType);
       return report;
     },
@@ -108,7 +108,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -116,7 +116,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const threatProfile = args.threat_profile as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
 
       if (!threatProfile) {
         return {
@@ -145,7 +145,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter by source type (optional)',
         },
       },
@@ -153,7 +153,7 @@ export const analysisTools = [
     },
     handler: async (args) => {
       const techniqueId = args.technique_id as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
 
       if (!techniqueId) {
         return {
@@ -202,7 +202,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter to specific source type (optional — includes all if omitted)',
         },
         tactic: {
@@ -232,7 +232,7 @@ export const analysisTools = [
       const layer = generateNavigatorLayer({
         name,
         description: args.description as string | undefined,
-        source_type: args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined,
+        source_type: args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined,
         tactic: args.tactic as string | undefined,
         severity: args.severity as string | undefined,
       });
@@ -257,7 +257,7 @@ export const analysisTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter to specific source (optional — analyzes all if omitted)',
         },
         include_query_snippets: {
@@ -278,7 +278,7 @@ export const analysisTools = [
         return { error: true, code: 'INVALID_TECHNIQUE_ID', message: validation.error, suggestion: validation.suggestion, similar: validation.similar };
       }
 
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
       const includeSnippets = args.include_query_snippets === true;
 
       return analyzeProcedureCoverageForTechnique(techniqueId, sourceType, includeSnippets);
@@ -299,7 +299,7 @@ export const analysisTools = [
           type: 'array',
           items: {
             type: 'string',
-            enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+            enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           },
           description: 'Sources to compare (default: all available)',
         },

--- a/src/tools/detections/comparison.ts
+++ b/src/tools/detections/comparison.ts
@@ -26,7 +26,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Optional: filter by source type',
         },
         limit: {
@@ -38,7 +38,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const query = args.query as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
       const limit = (args.limit as number) || 100;
 
       if (!query) {
@@ -174,7 +174,7 @@ export const comparisonTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Optional: filter to specific source',
         },
       },
@@ -182,7 +182,7 @@ export const comparisonTools = [
     },
     handler: async (args) => {
       const pattern = args.pattern as string;
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
 
       if (!pattern) {
         return {
@@ -272,13 +272,13 @@ export const comparisonTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter by source type (optional)',
         },
       },
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | undefined;
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect' | undefined;
       const report = analyzeCoverage(sourceType);
 
       // Return minimal data - just percentages

--- a/src/tools/detections/filters.ts
+++ b/src/tools/detections/filters.ts
@@ -26,7 +26,7 @@ export const filterTools = [
       properties: {
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Source type to filter by',
         },
         limit: {
@@ -41,7 +41,7 @@ export const filterTools = [
       required: ['source_type'],
     },
     handler: async (args) => {
-      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+      const sourceType = args.source_type as 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
       const limit = (args.limit as number) || 100;
       const offset = (args.offset as number) || 0;
 

--- a/src/tools/detections/search.ts
+++ b/src/tools/detections/search.ts
@@ -29,7 +29,7 @@ export const searchTools = [
         },
         source_type: {
           type: 'string',
-          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+          enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
           description: 'Filter results by detection source type',
         },
       },

--- a/src/tools/engineering/index.ts
+++ b/src/tools/engineering/index.ts
@@ -44,7 +44,7 @@ const getQueryPatternsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
         description: 'Filter patterns by source type (optional)',
       },
     },
@@ -205,7 +205,7 @@ const findSimilarDetectionsTool = defineTool({
       },
       source_type: {
         type: 'string',
-        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'],
+        enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'],
         description: 'Filter by source type (optional)',
       },
       limit: {

--- a/src/types/detection.ts
+++ b/src/types/detection.ts
@@ -11,7 +11,7 @@ export interface Detection {
   name: string;
   description: string;
   query: string; // detection logic (YAML for Sigma, SPL for Splunk, EQL/KQL for Elastic, MQL for Sublime)
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
   mitre_ids: string[];
   logsource_category: string | null;
   logsource_product: string | null;
@@ -55,7 +55,7 @@ export interface Detection {
 export interface DetectionSummary {
   id: string;
   name: string;
-  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql';
+  source_type: 'sigma' | 'splunk_escu' | 'elastic' | 'kql' | 'sublime' | 'crowdstrike_cql' | 'jamf_protect';
   mitre_ids: string[];
   severity: string | null;
   mitre_tactics: string[];
@@ -193,6 +193,30 @@ export interface ElasticTechnique {
   name?: string;
   reference?: string;
   subtechnique?: ElasticTechnique[];
+}
+
+/**
+ * Jamf Protect custom analytic detection structure (YAML with NSPredicate filter).
+ * @see https://github.com/jamf/jamfprotect/tree/main/custom_analytic_detections
+ */
+export interface JamfProtectRule {
+  name: string;
+  uuid?: string;
+  label?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  level?: number;
+  inputType?: 'GPProcessEvent' | 'GPFSEvent' | 'GPKeylogRegisterEvent' | 'GPUSBEvent' | string;
+  filter: string;
+  severity?: 'Informational' | 'Low' | 'Medium' | 'High' | 'Critical' | string;
+  categories?: string[];
+  MitreCategories?: string[] | null;
+  tags?: string[] | null;
+  snapshotFiles?: string[] | null;
+  actions?: Array<{ name?: string } | string>;
+  context?: string[] | null;
+  version?: number;
+  remediation?: string | null;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export type {
   ElasticTechnique,
   SublimeRule,
   CqlHubRule,
+  JamfProtectRule,
 } from './detection.js';
 
 // Story types

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -13,6 +13,8 @@ export interface IndexStats {
   elastic: number;
   kql: number;
   sublime: number;
+  crowdstrike_cql: number;
+  jamf_protect: number;
   by_severity: Record<string, number>;
   by_logsource_product: Record<string, number>;
   mitre_coverage: number;

--- a/tests/fixtures/jamf_protect/applescript_gather_clipboard.yaml
+++ b/tests/fixtures/jamf_protect/applescript_gather_clipboard.yaml
@@ -1,0 +1,25 @@
+---
+name: AppleScriptClipboardActivity
+uuid: 96cea4cc-a944-4220-9f8d-99d91622a6f5
+longDescription: This detection functions by monitoring for when AppleScript is being used to potentially gather clipboard contents over a defined time period or to generate a dialogue box and request the user to enter the keychain password.
+level: 0
+inputType: GPProcessEvent
+tags:
+snapshotFiles: []
+filter: $event.type == 1 AND
+  $event.process.signingInfo.appid == "com.apple.osascript" AND
+  $event.process.commandLine CONTAINS[c] "the clipboard"
+actions:
+  - name: Log
+context: []
+categories:
+  - Collection
+version: 1
+severity: Informational
+shortDescription: The osascript binary has been launched to capture the contents of the clipboard.
+label: AppleScript Clipboard Activity
+remediation: null
+MitreCategories:
+  - LivingOffTheLand
+  - CredentialAccess
+

--- a/tests/fixtures/jamf_protect/applescript_gather_clipboard.yaml
+++ b/tests/fixtures/jamf_protect/applescript_gather_clipboard.yaml
@@ -22,4 +22,3 @@ remediation: null
 MitreCategories:
   - LivingOffTheLand
   - CredentialAccess
-

--- a/tests/fixtures/jamf_protect/hidden_account_created_dscl.yaml
+++ b/tests/fixtures/jamf_protect/hidden_account_created_dscl.yaml
@@ -1,0 +1,25 @@
+---
+name: HiddenAccountCreatedDscl
+uuid: 7ee555e8-d911-4918-a9f1-c919675d02c5
+longDescription: This detection functions by monitoring on attempts using dcsl to create accounts that are hidden from the login window.
+level: 0
+inputType: GPProcessEvent
+tags:
+snapshotFiles: []
+filter: $event.type == 1 AND
+  ($event.process.path.lastPathComponent == "dscl" AND
+  ((ANY $event.process.args == "IsHidden") AND (ANY $event.process.args == "-create") AND (ANY $event.process.args IN {"true", "1", "yes"})))
+actions:
+  - name: Log
+context: []
+categories:
+  - Visibility
+  - Persistence
+version: 1
+severity: Informational
+shortDescription: A hidden user has been created using dscl.
+label: Hidden Account Created DSCL
+remediation: null
+MitreCategories:
+  - Persistence
+

--- a/tests/fixtures/jamf_protect/hidden_account_created_dscl.yaml
+++ b/tests/fixtures/jamf_protect/hidden_account_created_dscl.yaml
@@ -22,4 +22,3 @@ label: Hidden Account Created DSCL
 remediation: null
 MitreCategories:
   - Persistence
-

--- a/tests/fixtures/jamf_protect/known_vulnerable_log4j_jar_installation.yaml
+++ b/tests/fixtures/jamf_protect/known_vulnerable_log4j_jar_installation.yaml
@@ -1,0 +1,23 @@
+---
+name: KnownVulnerableLog4jJarInstallation
+uuid: 73647f5a-d508-4315-96fd-72798b3f82ea
+longDescription: This detection functions by monitoring for .jar files created on the host system that are known to be vulnerable to log4shell-related attacks.
+level: 0
+inputType: GPFSEvent
+tags:
+snapshotFiles: []
+filter: $event.type == 0 AND
+  $event.path.pathExtension ==[cd] "jar" AND
+  $event.path MATCHES ".*(apache-)?log4j-(\\d+(\\.|-)){1,3}((rc|beta)\\d+-)?(bin|alpha\\d+(-bin)?)/log4j-core-(?!2\\.3\\.[1-9]|2\\.17\\.[0-9]|2\\.12\\.[3-9])(\\d+(\\.|-)?){1,3}((alpha|beta|rc)\\d+)?\.jar"
+actions:
+  - name: Log
+context: []
+categories:
+  - System Visibility
+version: 1
+severity: Informational
+shortDescription: A .jar file has been created on the system.
+label: Known Vulnerable Log4j Jar Installation
+remediation: Review and cleanup the created .jar file.
+MitreCategories: null
+

--- a/tests/fixtures/jamf_protect/known_vulnerable_log4j_jar_installation.yaml
+++ b/tests/fixtures/jamf_protect/known_vulnerable_log4j_jar_installation.yaml
@@ -20,4 +20,3 @@ shortDescription: A .jar file has been created on the system.
 label: Known Vulnerable Log4j Jar Installation
 remediation: Review and cleanup the created .jar file.
 MitreCategories: null
-

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -168,6 +168,28 @@ test('Splunk detections have consistent structure', () => {
   }
 });
 
+test('Jamf Protect detections have macOS shape (if indexed)', () => {
+  const jamf = listBySource('jamf_protect', 50);
+
+  if (jamf.length === 0) {
+    console.log('   (No Jamf Protect rules indexed - skipping)');
+    return;
+  }
+
+  for (const rule of jamf.slice(0, 10)) {
+    assert(rule.id, 'Jamf detection should have an ID');
+    assert(rule.name, 'Jamf detection should have a name');
+    assert(rule.query, 'Jamf detection should have a filter/query');
+    assert(rule.platforms && rule.platforms.includes('macos'),
+      `Jamf detection "${rule.name}" should declare macos platform`);
+    if (rule.severity) {
+      assert(rule.severity === rule.severity.toLowerCase(),
+        `Jamf severity should be lowercased, got ${rule.severity}`);
+    }
+  }
+  console.log(`   ${jamf.length} Jamf Protect detections indexed`);
+});
+
 test('KQL rules have consistent structure (if indexed)', () => {
   const kqlRules = listBySource('kql', 50);
   

--- a/tests/jamf-parser-test.js
+++ b/tests/jamf-parser-test.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Jamf Protect parser fixture test.
+ *
+ * Directly exercises parseJamfProtectFile against checked-in fixtures so we
+ * can catch regressions in MITRE extraction, severity normalization, and
+ * macOS field handling without needing a full indexing run.
+ */
+
+import { parseJamfProtectFile } from '../dist/parsers/jamf_protect.js';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, 'fixtures', 'jamf_protect');
+
+const TESTS = [];
+const RESULTS = { passed: 0, failed: 0 };
+
+function test(name, fn) {
+  TESTS.push({ name, fn });
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function runTests() {
+  console.log('==============================================================');
+  console.log('  Jamf Protect Parser - Fixture Test');
+  console.log('==============================================================\n');
+
+  for (const { name, fn } of TESTS) {
+    try {
+      await fn();
+      console.log(`  PASS: ${name}`);
+      RESULTS.passed++;
+    } catch (error) {
+      console.log(`  FAIL: ${name}`);
+      console.log(`        ${error.message}`);
+      RESULTS.failed++;
+    }
+  }
+
+  console.log('\n' + '-'.repeat(60));
+  console.log(`Results: ${RESULTS.passed} passed, ${RESULTS.failed} failed`);
+  console.log('-'.repeat(60));
+
+  process.exit(RESULTS.failed > 0 ? 1 : 0);
+}
+
+// applescript_gather_clipboard: MitreCategories=[LivingOffTheLand, CredentialAccess]
+test('applescript_gather_clipboard parses with both a MITRE tactic and a Jamf-specific label mapped', () => {
+  const d = parseJamfProtectFile(join(FIXTURE_DIR, 'applescript_gather_clipboard.yaml'));
+  assert(d !== null, 'parser should return a detection');
+  assert(d.source_type === 'jamf_protect', `source_type should be jamf_protect, got ${d.source_type}`);
+  assert(d.id.startsWith('jamf-96cea4cc-a944-4220-9f8d-99d91622a6f5-'), `id should embed uuid with uniqueness suffix, got ${d.id}`);
+  assert(d.name === 'AppleScript Clipboard Activity', `label preferred over name, got ${d.name}`);
+  assert(d.severity === 'informational', `severity should be lowercased, got ${d.severity}`);
+  assert(d.platforms.includes('macos'), 'platforms should include macos');
+  assert(d.asset_type === 'Endpoint', 'asset_type should be Endpoint');
+  assert(d.security_domain === 'endpoint', 'security_domain should be endpoint');
+  assert(d.logsource_category === 'GPProcessEvent', `logsource_category should be GPProcessEvent, got ${d.logsource_category}`);
+  assert(d.data_sources.includes('Process Events'), 'data_sources should derive Process Events from GPProcessEvent');
+
+  // MitreCategories: [LivingOffTheLand, CredentialAccess]
+  // CredentialAccess → tactic credential-access
+  // LivingOffTheLand → techniques T1059, T1218 + tactics execution, defense-evasion
+  assert(d.mitre_tactics.includes('credential-access'), `mitre_tactics should include credential-access, got ${JSON.stringify(d.mitre_tactics)}`);
+  assert(d.mitre_tactics.includes('execution'), `LivingOffTheLand should map to execution tactic, got ${JSON.stringify(d.mitre_tactics)}`);
+  assert(d.mitre_tactics.includes('defense-evasion'), `LivingOffTheLand should map to defense-evasion tactic, got ${JSON.stringify(d.mitre_tactics)}`);
+  assert(d.mitre_ids.includes('T1059'), `LivingOffTheLand should map to T1059, got ${JSON.stringify(d.mitre_ids)}`);
+  assert(d.mitre_ids.includes('T1218'), `LivingOffTheLand should map to T1218, got ${JSON.stringify(d.mitre_ids)}`);
+
+  // Raw Jamf labels preserved in tags for searchability
+  assert(d.tags.includes('LivingOffTheLand'), 'raw Jamf label LivingOffTheLand should be preserved in tags');
+  assert(d.tags.includes('CredentialAccess'), 'raw tactic label should be preserved in tags');
+  assert(d.tags.includes('Collection'), 'categories value should be preserved in tags');
+
+  // Process name extraction: signingInfo.appid == "com.apple.osascript" → osascript
+  assert(d.process_names.includes('osascript'), `should extract osascript from appid pattern, got ${JSON.stringify(d.process_names)}`);
+});
+
+// known_vulnerable_log4j_jar_installation: MitreCategories=null, inputType=GPFSEvent
+test('known_vulnerable_log4j_jar_installation handles null MitreCategories', () => {
+  const d = parseJamfProtectFile(join(FIXTURE_DIR, 'known_vulnerable_log4j_jar_installation.yaml'));
+  assert(d !== null, 'parser should return a detection even with null MitreCategories');
+  assert(d.mitre_ids.length === 0, `mitre_ids should be empty for null MitreCategories, got ${JSON.stringify(d.mitre_ids)}`);
+  assert(d.mitre_tactics.length === 0, `mitre_tactics should be empty for null MitreCategories, got ${JSON.stringify(d.mitre_tactics)}`);
+  assert(d.logsource_category === 'GPFSEvent', `logsource_category should be GPFSEvent, got ${d.logsource_category}`);
+  assert(d.data_sources.includes('File System Events'), 'data_sources should map GPFSEvent → File System Events');
+});
+
+// hidden_account_created_dscl: MitreCategories=[Persistence]
+test('hidden_account_created_dscl extracts Persistence tactic and dscl process name', () => {
+  const d = parseJamfProtectFile(join(FIXTURE_DIR, 'hidden_account_created_dscl.yaml'));
+  assert(d !== null, 'parser should return a detection');
+  assert(d.mitre_tactics.includes('persistence'), `mitre_tactics should include persistence, got ${JSON.stringify(d.mitre_tactics)}`);
+  assert(d.process_names.includes('dscl'), `should extract dscl from lastPathComponent pattern, got ${JSON.stringify(d.process_names)}`);
+});
+
+test('parser returns null on unreadable file', () => {
+  const d = parseJamfProtectFile(join(FIXTURE_DIR, 'does-not-exist.yaml'));
+  assert(d === null, 'parser should return null for missing file');
+});
+
+runTests();

--- a/web/app/(app)/explore/[id]/page.tsx
+++ b/web/app/(app)/explore/[id]/page.tsx
@@ -41,6 +41,7 @@ export default async function DetectionDetailPage({
             detection.source_type === 'elastic' ? 'bg-orange/10 text-orange border-orange/30' :
             detection.source_type === 'kql' ? 'bg-amber/10 text-amber border-amber/30' :
             detection.source_type === 'sublime' ? 'bg-red/10 text-red border-red/30' :
+            detection.source_type === 'jamf_protect' ? 'bg-green/10 text-green border-green/30' :
             'bg-amber/10 text-amber border-amber/30'
           }`}>
             {detection.source_type}

--- a/web/app/(app)/explore/page.tsx
+++ b/web/app/(app)/explore/page.tsx
@@ -9,6 +9,7 @@ const SOURCES = [
   { key: 'kql', label: 'KQL' },
   { key: 'sublime', label: 'Sublime' },
   { key: 'crowdstrike_cql', label: 'CrowdStrike' },
+  { key: 'jamf_protect', label: 'Jamf Protect' },
 ];
 
 function severityBadge(severity: string | null) {
@@ -30,6 +31,7 @@ function sourceBadge(source: string) {
     kql: 'bg-amber/10 text-amber border-amber/30',
     sublime: 'bg-red/10 text-red border-red/30',
     crowdstrike_cql: 'bg-amber/10 text-amber border-amber/30',
+    jamf_protect: 'bg-green/10 text-green border-green/30',
   };
   return colors[source] || 'bg-text-dim/10 text-text-dim border-text-dim/30';
 }
@@ -38,6 +40,7 @@ function sourceLabel(source: string) {
   const labels: Record<string, string> = {
     sigma: 'Sigma', splunk_escu: 'Splunk', elastic: 'Elastic',
     kql: 'KQL', sublime: 'Sublime', crowdstrike_cql: 'CrowdStrike',
+    jamf_protect: 'Jamf Protect',
   };
   return labels[source] || source;
 }

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -956,7 +956,7 @@ async function buildDataDrivenResponse(userMessage: string, userId?: string): Pr
   }
 
   // Compare sources: "compare sigma vs elastic for T1059"
-  const srcCompareMatch = msg.match(/compare\s+(sigma|splunk|elastic|kql|sublime|crowdstrike).*(?:vs|and|with).*(?:for\s+)?(T\d{4}(?:\.\d{3})?)/i)
+  const srcCompareMatch = msg.match(/compare\s+(sigma|splunk|elastic|kql|sublime|crowdstrike|jamf).*(?:vs|and|with).*(?:for\s+)?(T\d{4}(?:\.\d{3})?)/i)
     || msg.match(/compare.*(?:sources?|coverage).*(?:for\s+)?(T\d{4}(?:\.\d{3})?)/i);
   if (srcCompareMatch) {
     const techId = (srcCompareMatch[2] || srcCompareMatch[1]).toUpperCase();

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -743,6 +743,7 @@ async function buildDataDrivenResponse(userMessage: string, userId?: string): Pr
     sigma: 'sigma', splunk: 'splunk_escu', escu: 'splunk_escu',
     elastic: 'elastic', kql: 'kql', sublime: 'sublime',
     crowdstrike: 'crowdstrike_cql', cql: 'crowdstrike_cql',
+    jamf: 'jamf_protect', jamf_protect: 'jamf_protect', macos: 'jamf_protect',
   };
   const sourceKeys = Object.keys(sourceNames).join('|');
 

--- a/web/app/api/mcp/[transport]/route.ts
+++ b/web/app/api/mcp/[transport]/route.ts
@@ -30,7 +30,7 @@ const handler = createMcpHandler(
       version: '1.0.0',
     },
     instructions:
-      'Hosted Security Detections MCP. Read-only access to ~8,000 detections from Sigma, Splunk ESCU, Elastic, KQL, Sublime, and CrowdStrike CQL. Start with get_stats() and get_coverage_summary(), then drill down with search, list_by_mitre, or analyze_actor_coverage.',
+      'Hosted Security Detections MCP. Read-only access to ~8,000 detections from Sigma, Splunk ESCU, Elastic, KQL, Sublime, CrowdStrike CQL, and Jamf Protect (macOS). Start with get_stats() and get_coverage_summary(), then drill down with search, list_by_mitre, or analyze_actor_coverage.',
   },
   {
     basePath: '/api/mcp',

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -27,12 +27,12 @@ const siteUrl = 'https://detect.michaelhaag.org';
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: 'Security Detections | AI-Powered Detection Coverage Intelligence',
-  description: 'Search 8,295+ security detections across Sigma, Splunk, Elastic, KQL, Sublime, and CrowdStrike. AI-powered coverage analysis, threat actor mapping, and gap assessment.',
+  description: 'Search 8,375+ security detections across Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike, and Jamf Protect (macOS). AI-powered coverage analysis, threat actor mapping, and gap assessment.',
   keywords: ['security detections', 'MITRE ATT&CK', 'Sigma rules', 'Splunk detections', 'threat coverage', 'detection engineering'],
   authors: [{ name: 'Michael Haag' }],
   openGraph: {
     title: 'Security Detections',
-    description: 'Search 8,295+ security detections across Sigma, Splunk, Elastic, KQL, Sublime, and CrowdStrike. AI-powered coverage analysis, threat actor mapping, and gap assessment.',
+    description: 'Search 8,375+ security detections across Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike, and Jamf Protect (macOS). AI-powered coverage analysis, threat actor mapping, and gap assessment.',
     url: siteUrl,
     siteName: 'Security Detections',
     type: 'website',
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Security Detections',
-    description: 'AI-Powered Detection Coverage Intelligence — 8,295+ detections across Sigma, Splunk, Elastic, KQL, Sublime, and CrowdStrike.',
+    description: 'AI-Powered Detection Coverage Intelligence — 8,375+ detections across Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike, and Jamf Protect.',
   },
 };
 

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -365,6 +365,7 @@ cd ..`}</CodeBlock>
   -e KQL_PATHS="/path/to/kql-bertjanp" \\
   -e SUBLIME_PATHS="/path/to/sublime-rules/detection-rules" \\
   -e CQL_HUB_PATHS="/path/to/cql-hub/queries" \\
+  -e JAMF_PROTECT_PATHS="/path/to/jamfprotect/custom_analytic_detections" \\
   -e STORY_PATHS="/path/to/security_content/stories" \\
   -e ATTACK_STIX_PATH="/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json" \\
   -- npx -y security-detections-mcp`}</CodeBlock>
@@ -385,6 +386,7 @@ cd ..`}</CodeBlock>
         "KQL_PATHS": "/path/to/kql-bertjanp",
         "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules",
         "CQL_HUB_PATHS": "/path/to/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/path/to/jamfprotect/custom_analytic_detections",
         "STORY_PATHS": "/path/to/security_content/stories",
         "ATTACK_STIX_PATH": "/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json"
       }
@@ -409,6 +411,7 @@ cd ..`}</CodeBlock>
         "KQL_PATHS": "/path/to/kql-bertjanp",
         "SUBLIME_PATHS": "/path/to/sublime-rules/detection-rules",
         "CQL_HUB_PATHS": "/path/to/cql-hub/queries",
+        "JAMF_PROTECT_PATHS": "/path/to/jamfprotect/custom_analytic_detections",
         "STORY_PATHS": "/path/to/security_content/stories",
         "ATTACK_STIX_PATH": "/path/to/attack-stix-data/enterprise-attack/enterprise-attack.json"
       }

--- a/web/app/mcp/page.tsx
+++ b/web/app/mcp/page.tsx
@@ -345,6 +345,11 @@ cd sublime-rules && git sparse-checkout set detection-rules && cd ..
 git clone --depth 1 \\
   https://github.com/ByteRay-Labs/Query-Hub.git cql-hub
 
+# Jamf Protect custom analytic detections (macOS, ~80)
+git clone --depth 1 --filter=blob:none --sparse \\
+  https://github.com/jamf/jamfprotect.git
+cd jamfprotect && git sparse-checkout set custom_analytic_detections && cd ..
+
 # MITRE ATT&CK STIX data (172 actors, 691 techniques, 784 software)
 git clone --depth 1 \\
   https://github.com/mitre-attack/attack-stix-data.git
@@ -497,7 +502,7 @@ cd ..`}</CodeBlock>
           </div>
 
           <p className="text-text-dim text-center text-xs mt-6 font-[family-name:var(--font-mono)]">
-            + 60 more tools for Sigma, Splunk, Elastic, KQL, Sublime, and CrowdStrike CQL specific operations
+            + 60 more tools for Sigma, Splunk, Elastic, KQL, Sublime, CrowdStrike CQL, and Jamf Protect specific operations
           </p>
         </div>
       </section>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -228,6 +228,7 @@ export default async function LandingPage() {
                 <SourceBadge name="Microsoft KQL" count="800+" />
                 <SourceBadge name="Sublime Security" count="500+" />
                 <SourceBadge name="CrowdStrike CQL" count="300+" />
+                <SourceBadge name="Jamf Protect (macOS)" count="80+" />
               </>
             )}
           </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -50,6 +50,7 @@ const sourceLabels: Record<string, string> = {
   kql: 'Microsoft KQL',
   sublime: 'Sublime Security',
   crowdstrike_cql: 'CrowdStrike CQL',
+  jamf_protect: 'Jamf Protect (macOS)',
 };
 
 function StatCard({ value, label, color }: { value: string; label: string; color: string }) {

--- a/web/lib/ai/tool-executor.ts
+++ b/web/lib/ai/tool-executor.ts
@@ -253,7 +253,7 @@ async function compareSources(args: Record<string, string>): Promise<string> {
   const detIds = detTechRows?.map(d => d.detection_id) || [];
 
   const bySource: Record<string, { count: number; detections: string[] }> = {};
-  const allSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'];
+  const allSources = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'];
 
   for (const src of allSources) {
     bySource[src] = { count: 0, detections: [] };

--- a/web/lib/ai/tools.ts
+++ b/web/lib/ai/tools.ts
@@ -21,7 +21,7 @@ export const AI_TOOLS: ToolDefinition[] = [
         type: 'object',
         properties: {
           query: { type: 'string', description: 'Search query (keywords, technique IDs, CVEs, process names)' },
-          source: { type: 'string', description: 'Filter by source', enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'] },
+          source: { type: 'string', description: 'Filter by source', enum: ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] },
           severity: { type: 'string', description: 'Filter by severity', enum: ['critical', 'high', 'medium', 'low'] },
           limit: { type: 'string', description: 'Max results (default 10)' },
         },

--- a/web/lib/mcp/db.ts
+++ b/web/lib/mcp/db.ts
@@ -44,7 +44,7 @@ export interface DetectionRow {
 const DETECTION_LIST_COLUMNS =
   'id, name, description, source_type, severity, mitre_ids, mitre_tactics, detection_type, data_sources';
 
-const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql'] as const;
+const SOURCE_TYPES = ['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect'] as const;
 export type SourceType = (typeof SOURCE_TYPES)[number];
 export const ALL_SOURCE_TYPES = SOURCE_TYPES;
 

--- a/web/lib/mcp/tools.ts
+++ b/web/lib/mcp/tools.ts
@@ -45,7 +45,7 @@ import {
 
 // ─── Schemas shared across tools ──────────────────────────────────────────
 
-const SOURCE_ENUM = z.enum(['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql']);
+const SOURCE_ENUM = z.enum(['sigma', 'splunk_escu', 'elastic', 'kql', 'sublime', 'crowdstrike_cql', 'jamf_protect']);
 const SEVERITY_ENUM = z.enum(['informational', 'low', 'medium', 'high', 'critical']);
 const TACTIC_ENUM = z.enum([
   'reconnaissance',
@@ -334,7 +334,7 @@ export function registerHostedTools(server: McpServer): void {
     'list_by_source',
     {
       title: 'List by Source',
-      description: 'List detections from a specific source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql).',
+      description: 'List detections from a specific source (sigma, splunk_escu, elastic, kql, sublime, crowdstrike_cql, jamf_protect).',
       inputSchema: {
         source_type: SOURCE_ENUM,
         limit: z.number().int().min(1).max(100).optional(),

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -35,6 +35,7 @@ export function sourceDisplayName(source: string): string {
     kql: 'Microsoft KQL',
     sublime: 'Sublime',
     crowdstrike_cql: 'CrowdStrike CQL',
+    jamf_protect: 'Jamf Protect',
   };
   return names[source] || source;
 }
@@ -48,6 +49,7 @@ export function sourceBadgeColor(source: string): string {
     kql: 'bg-amber/10 text-amber border-amber/30',
     sublime: 'bg-red/10 text-red border-red/30',
     crowdstrike_cql: 'bg-amber/10 text-amber border-amber/30',
+    jamf_protect: 'bg-green/10 text-green border-green/30',
   };
   return colors[source] || 'bg-text-dim/10 text-text-dim border-text-dim/30';
 }

--- a/web/supabase/migrations/002_rls_and_functions.sql
+++ b/web/supabase/migrations/002_rls_and_functions.sql
@@ -195,7 +195,7 @@ RETURNS JSON AS $$
     ),
     'sources_without_coverage', (
       SELECT array_agg(s.source_type)
-      FROM (VALUES ('sigma'), ('splunk_escu'), ('elastic'), ('kql'), ('sublime'), ('crowdstrike_cql')) AS s(source_type)
+      FROM (VALUES ('sigma'), ('splunk_escu'), ('elastic'), ('kql'), ('sublime'), ('crowdstrike_cql'), ('jamf_protect')) AS s(source_type)
       WHERE s.source_type NOT IN (
         SELECT DISTINCT d.source_type
         FROM detection_techniques dt JOIN detections d ON d.id = dt.detection_id
@@ -443,7 +443,7 @@ $$ LANGUAGE sql STABLE;
 CREATE OR REPLACE FUNCTION compare_sources_for_technique(p_technique_id TEXT)
 RETURNS JSON AS $$
   WITH all_sources AS (
-    SELECT unnest(ARRAY['sigma','splunk_escu','elastic','kql','sublime','crowdstrike_cql']) as source_type
+    SELECT unnest(ARRAY['sigma','splunk_escu','elastic','kql','sublime','crowdstrike_cql','jamf_protect']) as source_type
   ),
   source_dets AS (
     SELECT d.source_type, COUNT(*) as count,
@@ -468,7 +468,7 @@ RETURNS JSON AS $$
     ),
     'total_detections', (SELECT COALESCE(SUM(count), 0) FROM source_dets),
     'sources_with_coverage', (SELECT COUNT(*) FROM source_dets),
-    'sources_without_coverage', 6 - (SELECT COUNT(*) FROM source_dets)
+    'sources_without_coverage', 7 - (SELECT COUNT(*) FROM source_dets)
   );
 $$ LANGUAGE sql STABLE;
 

--- a/web/supabase/migrations/016_add_jamf_protect_source.sql
+++ b/web/supabase/migrations/016_add_jamf_protect_source.sql
@@ -1,0 +1,87 @@
+-- Re-create functions from 002_rls_and_functions.sql to include the new
+-- 'jamf_protect' source type. The hardcoded source arrays in these functions
+-- drive the "sources_without_coverage" gap analysis and the
+-- compare_sources_for_technique output — without this, Jamf Protect would
+-- never show up as a source, even after its rows are seeded.
+
+CREATE OR REPLACE FUNCTION get_technique_intelligence(p_technique_id TEXT)
+RETURNS JSON AS $$
+  SELECT json_build_object(
+    'technique_id', p_technique_id,
+    'technique_name', (SELECT name FROM attack_techniques WHERE technique_id = p_technique_id),
+    'description', (SELECT LEFT(description, 500) FROM attack_techniques WHERE technique_id = p_technique_id),
+    'platforms', (SELECT platforms FROM attack_techniques WHERE technique_id = p_technique_id),
+    'total_detections', (SELECT COUNT(*) FROM detection_techniques WHERE technique_id = p_technique_id),
+    'by_source', (
+      SELECT json_agg(json_build_object('source', source_type, 'count', cnt, 'detections', det_names))
+      FROM (
+        SELECT d.source_type, COUNT(*) as cnt,
+               json_agg(json_build_object('name', d.name, 'severity', d.severity) ORDER BY d.name) FILTER (WHERE d.name IS NOT NULL) as det_names
+        FROM detection_techniques dt
+        JOIN detections d ON d.id = dt.detection_id
+        WHERE dt.technique_id = p_technique_id
+        GROUP BY d.source_type
+        ORDER BY cnt DESC
+      ) sub
+    ),
+    'sources_with_coverage', (
+      SELECT array_agg(DISTINCT d.source_type)
+      FROM detection_techniques dt JOIN detections d ON d.id = dt.detection_id
+      WHERE dt.technique_id = p_technique_id
+    ),
+    'sources_without_coverage', (
+      SELECT array_agg(s.source_type)
+      FROM (VALUES ('sigma'), ('splunk_escu'), ('elastic'), ('kql'), ('sublime'), ('crowdstrike_cql'), ('jamf_protect')) AS s(source_type)
+      WHERE s.source_type NOT IN (
+        SELECT DISTINCT d.source_type
+        FROM detection_techniques dt JOIN detections d ON d.id = dt.detection_id
+        WHERE dt.technique_id = p_technique_id
+      )
+    ),
+    'actors_using', (
+      SELECT json_agg(json_build_object('name', aa.name, 'actor_id', aa.actor_id))
+      FROM actor_techniques at2
+      JOIN attack_actors aa ON aa.actor_id = at2.actor_id
+      WHERE at2.technique_id = p_technique_id
+    ),
+    'related_techniques', (
+      SELECT json_agg(DISTINCT at3.technique_id)
+      FROM attack_techniques at3
+      WHERE at3.parent_technique_id = SPLIT_PART(p_technique_id, '.', 1)
+        AND at3.technique_id != p_technique_id
+    )
+  );
+$$ LANGUAGE sql STABLE;
+
+
+CREATE OR REPLACE FUNCTION compare_sources_for_technique(p_technique_id TEXT)
+RETURNS JSON AS $$
+  WITH all_sources AS (
+    SELECT unnest(ARRAY['sigma','splunk_escu','elastic','kql','sublime','crowdstrike_cql','jamf_protect']) as source_type
+  ),
+  source_dets AS (
+    SELECT d.source_type, COUNT(*) as count,
+           json_agg(json_build_object('name', d.name, 'severity', d.severity) ORDER BY d.name) as detections
+    FROM detection_techniques dt
+    JOIN detections d ON d.id = dt.detection_id
+    WHERE dt.technique_id = p_technique_id
+    GROUP BY d.source_type
+  )
+  SELECT json_build_object(
+    'technique_id', p_technique_id,
+    'technique_name', (SELECT name FROM attack_techniques WHERE technique_id = p_technique_id),
+    'sources', (
+      SELECT json_agg(json_build_object(
+        'source', s.source_type,
+        'count', COALESCE(sd.count, 0),
+        'has_coverage', sd.count IS NOT NULL,
+        'detections', COALESCE(sd.detections, '[]'::json)
+      ) ORDER BY COALESCE(sd.count, 0) DESC)
+      FROM all_sources s
+      LEFT JOIN source_dets sd ON sd.source_type = s.source_type
+    ),
+    'total_detections', (SELECT COALESCE(SUM(count), 0) FROM source_dets),
+    'sources_with_coverage', (SELECT COUNT(*) FROM source_dets),
+    'sources_without_coverage', 7 - (SELECT COUNT(*) FROM source_dets)
+  );
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
## Summary

- Adds **Jamf Protect** `custom_analytic_detections` (macOS) as a first-class source alongside Sigma / Splunk ESCU / Elastic / KQL / Sublime / CrowdStrike CQL. 80 YAML rules ingest end-to-end from upstream.
- New `src/parsers/jamf_protect.ts` parses NSPredicate-style filters, normalizes severity, extracts process names + file paths, and does **best-effort MITRE mapping** for Jamf-specific category labels (`LivingOffTheLand` → `T1059`+`T1218`, `AdversaryInTheMiddle` → `T1557`, etc.) so they contribute to coverage analytics instead of hiding in `tags`.
- Workflow + web dashboard updated: nightly sync clones `jamfprotect` sparse and sets `JAMF_PROTECT_PATHS`; explore filter, source badge, chat aliases, and MCP tool schemas all know about `jamf_protect`.

## Verification

Local end-to-end on `MHaggis/jamf-protect-source` branch:
- \`npm run lint\` — clean
- \`npm run build\` — clean
- \`npm run test:jamf\` — 4/4 pass (fixture-based parser test)
- Indexed **80/80** Jamf YAMLs into the SQLite DB.
- **41/80** have MITRE tactics, **13/80** have technique IDs (T1055, T1059, T1218, T1557) from the best-effort label map.
- All 4 inputTypes (\`GPProcessEvent\` 58, \`GPFSEvent\` 20, \`GPKeylogRegisterEvent\` 1, \`GPUSBEvent\` 1) surface as \`data_sources\`.
- FTS search \`MATCH 'applescript'\` → 3 Jamf rules.
- All 80 tagged \`platforms=['macos']\`, \`asset_type='Endpoint'\`, \`security_domain='endpoint'\`.
- Severities normalized: 71 \`informational\`, 6 \`low\`, 2 \`medium\`.
- Process names extracted from NSPredicate: \`osascript\`, \`dscl\`, \`node\`, \`sudo\`, \`sharingd\`, etc.
- Combined \`SIGMA_PATHS\` + \`JAMF_PROTECT_PATHS\` ingest: 3,116 Sigma + 80 Jamf, no regression.
- \`tests/integration-test.js\` jamf block passes; pre-existing Splunk-pattern-extraction tests that need Splunk content still behave as before.

## Notes

- Upstream Jamf repo has two files sharing the same \`uuid\` (\`openclaw_directory_created\` + \`openclaw_onboard\`). \`generateId\` now embeds both the upstream uuid **and** a path hash so upstream collisions don't silently overwrite rows.
- No Supabase schema migration needed: \`detections.source_type\` is plain \`TEXT\` with no CHECK enum.
- \`rebuild_index\` tool also gained the missing \`SUBLIME_PATHS\` and \`CQL_HUB_PATHS\` constants as a drive-by fix — previously it accepted the env vars on startup but didn't pass them through on manual rebuild.

## Test plan

- [ ] CI nightly-sync workflow runs and ingests Jamf content without errors
- [ ] Hosted Supabase seed picks up jamf_protect rows (run manually or wait for nightly)
- [ ] Explore page \`?source=jamf_protect\` filter returns results once seeded
- [ ] \`list_by_source\` MCP tool accepts \`jamf_protect\`